### PR TITLE
3.7.6 Standard_vanilla

### DIFF
--- a/RNGS_SPAWN_MOD/3.7.6/Standard_vanilla_bosses/factory4_day/base.json
+++ b/RNGS_SPAWN_MOD/3.7.6/Standard_vanilla_bosses/factory4_day/base.json
@@ -1,0 +1,3927 @@
+{
+  "AccessKeys": [],
+  "Area": 0.9,
+  "AveragePlayTime": 15,
+  "AveragePlayerLevel": 1,
+  "Banners": [
+    {
+      "id": "5464e0404bdc2d2a708b4567",
+      "pic": {
+        "path": "CONTENT/banners/banner_usec.jpg",
+        "rcid": ""
+      }
+    },
+    {
+      "id": "5464e0454bdc2d06708b4567",
+      "pic": {
+        "path": "CONTENT/banners/banner_bear.jpg",
+        "rcid": ""
+      }
+    },
+    {
+      "id": "5803a58524597710ca36fcb2",
+      "pic": {
+        "path": "CONTENT/banners/banner_terragroup.jpg",
+        "rcid": ""
+      }
+    },
+    {
+      "id": "5807bfe124597742a92e0a4c",
+      "pic": {
+        "path": "CONTENT/banners/norvinskzone.jpg",
+        "rcid": ""
+      }
+    },
+    {
+      "id": "5807c3f124597746bf2db2ce",
+      "pic": {
+        "path": "CONTENT/banners/banner_scav.jpg",
+        "rcid": ""
+      }
+    },
+    {
+      "id": "5807be8924597742c603fa19",
+      "pic": {
+        "path": "CONTENT/banners/banner_tarkov.jpg",
+        "rcid": ""
+      }
+    },
+    {
+      "id": "5805f617245977100b2c1f41",
+      "pic": {
+        "path": "CONTENT/banners/tglabs.jpg",
+        "rcid": ""
+      }
+    },
+    {
+      "id": "5c1b857086f77465f465faa4",
+      "pic": {
+        "path": "CONTENT/banners/banner_scavraider.jpg",
+        "rcid": ""
+      }
+    },
+    {
+      "id": "64c0ad6af99768b777048f4e",
+      "pic": {
+        "path": "CONTENT/banners/banner_emissary.jpg",
+        "rcid": ""
+      }
+    }
+  ],
+  "BossLocationSpawn": [
+    {
+      "BossName": "bossTagilla",
+      "BossChance": 25,
+      "BossZone": "BotZone",
+      "BossPlayer": false,
+      "BossDifficult": "normal",
+      "BossEscortType": "followerBully",
+      "BossEscortDifficult": "normal",
+      "BossEscortAmount": "0",
+      "Time": -1,
+      "RandomTimeSpawn": false
+  }
+  ],
+  "BotAssault": 0,
+  "BotEasy": 0,
+  "BotHard": 0,
+  "BotImpossible": 0,
+  "BotLocationModifier": {
+    "AccuracySpeed": 1,
+    "DistToActivate": 140,
+    "DistToPersueAxemanCoef": 0.9,
+    "DistToSleep": 150,
+    "GainSight": 1,
+    "KhorovodChance": 0,
+    "MagnetPower": 15,
+    "MarksmanAccuratyCoef": 1,
+    "Scattering": 1,
+    "VisibleDistance": 1
+  },
+  "BotMarksman": 0,
+  "BotMax": 0,
+  "BotMaxPlayer": 0,
+  "BotMaxTimePlayer": 0,
+  "BotNormal": 0,
+  "BotSpawnCountStep": 3,
+  "BotSpawnPeriodCheck": 15,
+  "BotSpawnTimeOffMax": 0,
+  "BotSpawnTimeOffMin": 0,
+  "BotSpawnTimeOnMax": 0,
+  "BotSpawnTimeOnMin": 0,
+  "BotStart": 0,
+  "BotStartPlayer": 0,
+  "BotStop": 0,
+  "Description": "The industrial estate and facilities of the chemical plant No.16 that were rented out illegally to the TerraGroup company. ",
+  "DisabledForScav": false,
+  "DisabledScavExits": "Cellars,Gate 0",
+  "EnableCoop": true,
+  "Enabled": true,
+  "EscapeTimeLimit": 20,
+  "EscapeTimeLimitCoop": 15,
+  "GenerateLocalLootCache": true,
+  "GlobalContainerChanceModifier": 1,
+  "GlobalLootChanceModifier": 0.2,
+  "IconX": 318,
+  "IconY": 359,
+  "Id": "factory4_day",
+  "Insurance": true,
+  "IsSecret": false,
+  "Locked": false,
+  "Loot": [],
+  "MatchMakerMinPlayersByWaitTime": [
+    {
+      "minPlayers": 4,
+      "time": 60
+    },
+    {
+      "minPlayers": 3,
+      "time": 120
+    },
+    {
+      "minPlayers": 2,
+      "time": 250
+    },
+    {
+      "minPlayers": 1,
+      "time": 330
+    }
+  ],
+  "MaxBotPerZone": 4,
+  "MaxCoopGroup": 6,
+  "MaxDistToFreePoint": 900,
+  "MaxPlayers": 6,
+  "MinDistToExitPoint": 30,
+  "MinDistToFreePoint": 10,
+  "MinMaxBots": [],
+  "MinPlayerLvlAccessKeys": 0,
+  "MinPlayers": 5,
+  "Name": "Factory",
+  "NewSpawn": false,
+  "NonWaveGroupScenario": {
+    "Chance": 50,
+    "Enabled": true,
+    "MaxToBeGroup": 3,
+    "MinToBeGroup": 2
+  },
+  "OcculsionCullingEnabled": true,
+  "OfflineNewSpawn": false,
+  "OfflineOldSpawn": true,
+  "OldSpawn": true,
+  "OpenZones": "BotZone",
+  "PlayersRequestCount": -1,
+  "PmcMaxPlayersInGroup": 5,
+  "Preview": {
+    "path": "",
+    "rcid": ""
+  },
+  "RequiredPlayerLevelMax": 100,
+  "RequiredPlayerLevelMin": 0,
+  "Rules": "AvoidOwnPmc",
+  "SafeLocation": false,
+  "ScavMaxPlayersInGroup": 4,
+  "Scene": {
+    "path": "maps/factory_day_preset.bundle",
+    "rcid": "factory_day.scenespreset.asset"
+  },
+  "SpawnPointParams": [
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "0246436c-7d69-4036-999d-ebcb956970b5",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -29.763,
+        "y": 0.21,
+        "z": 7.584
+      },
+      "Rotation": 54.99,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "02e4bb08-990a-487c-a832-5a04582891d4",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 51.1948128,
+        "y": 0.0901808739,
+        "z": -25.5231
+      },
+      "Rotation": 3.0047307,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "03526917-c391-4233-ab31-89f70621c9d4",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -34.21619,
+        "y": 1.08018088,
+        "z": 46.2559052
+      },
+      "Rotation": 96.73777,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "03a779de-ef2d-43e3-a4f3-fdcfed474f05",
+      "Infiltration": "",
+      "Position": {
+        "x": 13.78,
+        "y": -2.291,
+        "z": -21.65
+      },
+      "Rotation": 81.2727051,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "05e75eb3-eb43-46c6-94d3-59e1e9ba4435",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -21.614,
+        "y": -2.62,
+        "z": 37.611
+      },
+      "Rotation": 160.78,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "0a92f51c-52b4-4e76-b839-f7ce82f2b36b",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 59.594,
+        "y": 0.103,
+        "z": 22.151
+      },
+      "Rotation": 53.49001,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "0e95dd99-d6b7-4562-9813-74d4da9aaf6f",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 49.5,
+        "y": 0.0729999542,
+        "z": 19.4500027
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "105e5c93-2399-4054-b31d-ec981a66491f",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 46.57556,
+        "y": 0.101000071,
+        "z": 23.17298
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "120a0777-e825-4de7-a855-c3eaa8eba46b",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -28.958,
+        "y": 0.21,
+        "z": 6.595
+      },
+      "Rotation": 54.99,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "13883982-2ab8-4dd5-a9b4-45e2c6d8e1cc",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -20.215,
+        "y": -2.62,
+        "z": 38.789
+      },
+      "Rotation": 160.78,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "184cc4d8-9007-4769-9798-8e354e9229ec",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -32.88419,
+        "y": 1.15018082,
+        "z": 47.0939026
+      },
+      "Rotation": 96.73777,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "1a5819f2-ff42-4632-af5e-fe5ea8f886fc",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 61,
+        "y": 0.117,
+        "z": 20.95
+      },
+      "Rotation": 53.49001,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "1d42b19c-7a5b-4684-9689-b801a89e041c",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -33.0051842,
+        "y": 1.08018088,
+        "z": 46.6718979
+      },
+      "Rotation": 96.73777,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "1facfcfc-9ee5-4638-83b3-117fce7b3303",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -30.978,
+        "y": 0.21,
+        "z": 6.713
+      },
+      "Rotation": 54.99,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "22a7740a-5a91-4bca-af36-668342522b42",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 70.465,
+        "y": 0.211,
+        "z": -61.785
+      },
+      "Rotation": 56.43,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 41.97
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "2355be95-341b-46db-90fd-6a383e286e5c",
+      "Infiltration": "",
+      "Position": {
+        "x": -20.756,
+        "y": 0.166,
+        "z": 22.769
+      },
+      "Rotation": 101.387489,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "27da5013-1a81-42db-a71f-312a557af54a",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -35.4081841,
+        "y": 1.08018088,
+        "z": 48.8108978
+      },
+      "Rotation": 96.73777,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "2875ed6d-0a92-4473-b641-0616a69f6388",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 49.989624,
+        "y": 0.0599999428,
+        "z": 15.7763767
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "2984a7ec-f10b-42a8-b466-554f37f9ea3e",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 43.8973656,
+        "y": 0.1170001,
+        "z": 23.56006
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "2a1f1b80-72be-444d-9d8d-5f645a3fc019",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 46.163,
+        "y": 0.16,
+        "z": -37.009
+      },
+      "Rotation": 0,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "2a5aad92-b5f9-40c0-a380-460247300227",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 60.445,
+        "y": 0.073,
+        "z": 19.302
+      },
+      "Rotation": 53.49001,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 21.1
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "2dcddca6-9bd7-4d57-b57d-4c013342190d",
+      "Infiltration": "",
+      "Position": {
+        "x": -19.19,
+        "y": -3.78,
+        "z": -4.91
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "2e1843a1-fd2a-4ccd-8b38-747c1a70f228",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -8.413,
+        "y": 0.005,
+        "z": -33.898
+      },
+      "Rotation": 340.262238,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "2eed18b6-9fbb-40de-979f-985f203f251e",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -28.19,
+        "y": 0.21,
+        "z": 5.58
+      },
+      "Rotation": 54.99,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "30edcdf0-73e0-4ab5-a9e7-4d24a9a83aa9",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 28.464,
+        "y": 0.244,
+        "z": 16.991
+      },
+      "Rotation": 77.36217,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "336d3c25-9f38-475f-8eb9-db6393f06b6c",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 67.872,
+        "y": 0.245,
+        "z": -60.357
+      },
+      "Rotation": 56.43,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "35e7edfa-5d6c-4512-b3f0-ebb823e076de",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 49.94165,
+        "y": 0.102999926,
+        "z": 22.0510311
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "38a8fe02-f871-4b79-91e5-69c2c68d1bbc",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -4.123,
+        "y": 0.005,
+        "z": -34.711
+      },
+      "Rotation": 359.768463,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "3bcd754a-b299-4d63-9d7f-e4d05c2f13e3",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -23.044,
+        "y": 1.07,
+        "z": 65.688
+      },
+      "Rotation": 263.74,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "3dd5759f-3764-491f-be62-82f2db15a699",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 51.404438,
+        "y": 0.0599999428,
+        "z": 21.1870213
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "3eed3347-ac2d-429b-870e-6e6bc076e05e",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 45.8,
+        "y": 0.0599999428,
+        "z": 20.9
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "3f0277ba-5d1f-4e3d-b763-234a33b904e3",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 49.5018044,
+        "y": 0.1170001,
+        "z": 23.8470821
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "4393a80b-14da-4321-86c4-0d45ab6afa67",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 48.6368141,
+        "y": 0.11818099,
+        "z": -25.4841
+      },
+      "Rotation": 3.0047307,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "4755c538-4ee5-4125-8cd3-885787da7ad5",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 19.87,
+        "y": -2.61,
+        "z": -1.3
+      },
+      "Rotation": 0,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "47a23e13-9db9-4cc2-8da0-fcbc52d698d8",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -35.38319,
+        "y": 1.08018088,
+        "z": 50.6099
+      },
+      "Rotation": 96.73777,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "4a4e5ee5-a314-4a78-939d-cf3c05818435",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -4.765,
+        "y": 0.005,
+        "z": -33.066
+      },
+      "Rotation": 53.49001,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "4bc2255b-75b0-44a3-91ed-c1b35499cbc5",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -17.21,
+        "y": -2.62,
+        "z": 38.282
+      },
+      "Rotation": 160.78,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "503cf951-8e80-4ca0-aa2d-993f71a6a4a6",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -51.426,
+        "y": 1.353,
+        "z": 54.339
+      },
+      "Rotation": 118.999352,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "50560c89-4136-4cfb-b155-485519110c93",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -3.503,
+        "y": 0.005,
+        "z": -32.728
+      },
+      "Rotation": 53.49001,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "57254982-c470-440d-911a-e8854f42398a",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -52.617,
+        "y": 1.353,
+        "z": 55.629
+      },
+      "Rotation": 118.999352,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "58eb6051-b050-4ce0-b608-71759c5e05b2",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -35.45019,
+        "y": 1.08018088,
+        "z": 47.646904
+      },
+      "Rotation": 96.73777,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "595f96c9-dcf7-4b89-947c-6f5538176fe2",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 52.02281,
+        "y": 0.0901808739,
+        "z": -24.6441
+      },
+      "Rotation": 3.0047307,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 21.1
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "5a2aaa7e-06d3-438b-a2ee-2781ed753d2d",
+      "Infiltration": "",
+      "Position": {
+        "x": 35.545,
+        "y": 8.231328,
+        "z": 36.41
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "5be1a535-4865-433c-b645-33c7ff65bd94",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -31.67,
+        "y": 0.21,
+        "z": 8.2
+      },
+      "Rotation": 54.99,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "5f9f188b-8489-4c06-ae14-ba4ca2a46028",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 46.0596237,
+        "y": 0.03700018,
+        "z": 15.1563778
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "60b47eab-b2a6-4ba2-b30c-fea14a7169bf",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 68.514,
+        "y": 0.194,
+        "z": -4.796
+      },
+      "Rotation": 5.86497259,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "6670b804-5f1a-45f1-a462-585cb8619d09",
+      "Infiltration": "",
+      "Position": {
+        "x": 8.07,
+        "y": 0.1,
+        "z": -8.61
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnBoxParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Size": {
+            "x": 40,
+            "y": 4,
+            "z": 40
+          }
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "67fb48f8-0359-458b-876c-2e4963cbd14e",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -5.93,
+        "y": -3.889,
+        "z": -22.49
+      },
+      "Rotation": 1.93020487,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "683f2734-6398-4b77-9bab-b87f3be35938",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 69.644,
+        "y": 0.211,
+        "z": -60.426
+      },
+      "Rotation": 56.43,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 21.1
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "68ac9245-633b-4287-a999-2c3028fa8d45",
+      "Infiltration": "",
+      "Position": {
+        "x": 4.73,
+        "y": 0.01,
+        "z": -35.1
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "68f38db1-e55e-4170-9e79-1f9e34e8cdc5",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 44.15699,
+        "y": 0.0940001,
+        "z": 17.8164349
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "6d7bf2bb-6211-4495-8509-58ceadea72e0",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -18.579,
+        "y": -2.62,
+        "z": 38.04
+      },
+      "Rotation": 160.78,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "6d97a439-de10-42c5-99ef-6cf92e243aca",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 17.043,
+        "y": -2.61,
+        "z": -2.117
+      },
+      "Rotation": 183.2318,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnBoxParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Size": {
+            "x": 40,
+            "y": 4,
+            "z": 50
+          }
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "6ecc9492-5fbb-43d8-a0c0-8509fa39eb1d",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -2.238,
+        "y": -3.905,
+        "z": -15.408
+      },
+      "Rotation": 1.93020487,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "74059b40-4072-495f-a02c-2ffce404d728",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 32.213,
+        "y": 2.333,
+        "z": 18.67
+      },
+      "Rotation": 249.746887,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "792180b4-c67c-45f6-a5d4-f3973c7e2c9b",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 45.914814,
+        "y": 0.11818099,
+        "z": -26.4251
+      },
+      "Rotation": 3.0047307,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "7ea1b4b8-a496-4bc0-bf61-e5ba4f3aa1fa",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 43.604,
+        "y": 0.16,
+        "z": -36.675
+      },
+      "Rotation": 0,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "80532206-b2e1-4578-b559-99eae931a957",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 46.118,
+        "y": 0.16,
+        "z": -39.159
+      },
+      "Rotation": 0,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "8128ea83-0d4f-4e64-b109-5acc9e477b33",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 69.838,
+        "y": 0.194,
+        "z": -6.105
+      },
+      "Rotation": 5.86497259,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "824c7aed-9a71-4158-91e4-a153c42bbddc",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 47.3188133,
+        "y": 0.11818099,
+        "z": -25.6161
+      },
+      "Rotation": 3.0047307,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "8429bed9-52e2-4731-a425-4912db8529a9",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 57.902,
+        "y": 0.06,
+        "z": 21.998
+      },
+      "Rotation": 53.49001,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "867576c4-1152-48ad-80bf-a802d7318379",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -49.516,
+        "y": 1.353,
+        "z": 55.556
+      },
+      "Rotation": 118.999352,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 41.97
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "86ff84ac-edf7-4efd-9643-4bacc59073e7",
+      "Infiltration": "",
+      "Position": {
+        "x": -6.77,
+        "y": 0.17,
+        "z": 10.01
+      },
+      "Rotation": 327.8234,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "8df78011-1568-4e66-99b8-5c4ed736b99a",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -6.95,
+        "y": 0.005,
+        "z": -32.83
+      },
+      "Rotation": 315.70224,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 41.97
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "90da8fb3-422a-46cd-b540-648cde8ee9f3",
+      "Infiltration": "",
+      "Position": {
+        "x": 23.83,
+        "y": -2.604,
+        "z": -30.66
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "91ec8f79-6cc4-422d-966f-4cd6a02d5a87",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -21.217,
+        "y": -2.62,
+        "z": 40.645
+      },
+      "Rotation": 160.78,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "92822146-7c98-4570-8bde-8d0d042ae3cf",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 43.591,
+        "y": 0.16,
+        "z": -38.865
+      },
+      "Rotation": 0,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "9507dd40-370d-4d8f-994e-c8f3b456804e",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -34.0161858,
+        "y": 1.08018088,
+        "z": 48.5449
+      },
+      "Rotation": 96.73777,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnBoxParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Size": {
+            "x": 40,
+            "y": 4,
+            "z": 40
+          }
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "990aa5a0-d549-4479-8af2-a196ddb3bb35",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -8.58,
+        "y": -3.905,
+        "z": -18.89
+      },
+      "Rotation": 84.01993,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "99840da7-52c4-4f5f-832e-c705e9d07572",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 50.914814,
+        "y": 0.0729999542,
+        "z": 24.8606472
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "99b05e61-8c54-42ad-bb6c-9bd30f38f1e6",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -34.0831871,
+        "y": 1.08018088,
+        "z": 47.0599
+      },
+      "Rotation": 96.73777,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "9dd99893-91c5-4e64-b808-bbe46852022a",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 58.6,
+        "y": 0.101,
+        "z": 19.7
+      },
+      "Rotation": 53.49001,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "9e274f37-1c37-4c56-a763-f0753921744b",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 50.55981,
+        "y": 0.11818099,
+        "z": -23.1311
+      },
+      "Rotation": 3.0047307,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "9f14e22f-3971-4440-8f48-c597cc7d9166",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 30.238,
+        "y": 0.256,
+        "z": 15.246
+      },
+      "Rotation": 77.36217,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 21.1
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "a5465833-c434-44d5-9bba-1ce6d8488884",
+      "Infiltration": "",
+      "Position": {
+        "x": 36.043,
+        "y": 1.09,
+        "z": 38.349
+      },
+      "Rotation": 182.971283,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "a5a35da1-0545-4774-b5a0-194f4903a9de",
+      "Infiltration": "",
+      "Position": {
+        "x": -5.89,
+        "y": 0.08,
+        "z": -27.46
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "a5c47219-1ebc-4254-90cb-934d6f9d4790",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -20.958,
+        "y": 1.07,
+        "z": 65.523
+      },
+      "Rotation": 93.9956055,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "a7c5ae7b-61a6-4f62-b975-46078fd443c6",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 50.1178131,
+        "y": 0.0901808739,
+        "z": -25.6021
+      },
+      "Rotation": 3.0047307,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "acdd7189-0c4b-4be6-9e6e-57dbca0f6212",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 44.5968361,
+        "y": 0.07999992,
+        "z": 16.0203838
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "ad0cbd99-02ee-4ff1-b799-6b50b8a3fa0f",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 68.564,
+        "y": 0.245,
+        "z": -61.448
+      },
+      "Rotation": 56.43,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "adee9078-b5a3-4f9e-b384-e984cbea15fc",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -52.297,
+        "y": 1.353,
+        "z": 57.053
+      },
+      "Rotation": 118.999352,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "ae4693d5-a309-4cbc-85db-ce8a59cf7ff4",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 44.96,
+        "y": 0.16,
+        "z": -37.574
+      },
+      "Rotation": 0,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "af54940c-1d1c-4281-a44d-cb2cf46e436b",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 46.835186,
+        "y": 0.07800007,
+        "z": 17.4293537
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "afacfed6-7a03-418b-9fca-420590d639c0",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 69.275,
+        "y": 0.245,
+        "z": -62.56
+      },
+      "Rotation": 56.43,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "b776e3ed-a02d-4141-8eba-35d4746547ca",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -51.114,
+        "y": 1.353,
+        "z": 55.87
+      },
+      "Rotation": 118.999352,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 21.1
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "bbb167e6-da45-42ff-a113-20f605521b02",
+      "Infiltration": "",
+      "Position": {
+        "x": 31.75,
+        "y": 0.15318726,
+        "z": -0.3
+      },
+      "Rotation": 84.78185,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "bc1a8dad-c186-4238-9340-90ac952050e6",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 48.08699,
+        "y": 0.1170001,
+        "z": 18.4364376
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "bcae7a9f-8b2f-4a4c-9cb0-589d4a227c70",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 22.331,
+        "y": -2.61,
+        "z": 0.232
+      },
+      "Rotation": 0,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "bd7f0d51-e000-4dc8-a58f-4bc9081039e3",
+      "Infiltration": "",
+      "Position": {
+        "x": -19.94,
+        "y": 1.11607242,
+        "z": 62.87
+      },
+      "Rotation": 157.772064,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "be7bf7f0-6892-4d55-b1af-85492250ea55",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 69.994,
+        "y": 0.194,
+        "z": -8.13
+      },
+      "Rotation": 5.86497259,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 41.97
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "c151498d-5939-4451-a992-c3998d62061a",
+      "Infiltration": "",
+      "Position": {
+        "x": 22.37,
+        "y": 0.86,
+        "z": 4.33
+      },
+      "Rotation": 113.499405,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "c249a42b-3b54-4680-ac4d-2c923ca4f530",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 30.674,
+        "y": 0.264,
+        "z": 20.54
+      },
+      "Rotation": 77.36217,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "c2d01ce0-e0e4-41af-8311-44dc5cf38a93",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 68.624,
+        "y": 0.194,
+        "z": -8.916
+      },
+      "Rotation": 184.931458,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "c3ba287a-9bea-4c28-81a5-650df99b2798",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 44.4868126,
+        "y": 0.11818099,
+        "z": -26.6101
+      },
+      "Rotation": 3.0047307,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "c671337f-e58f-4de6-a387-307d877954a3",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 18.411,
+        "y": -2.61,
+        "z": -1.321
+      },
+      "Rotation": 0,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "c949937b-c669-41ab-a5d6-1f93e58d4af8",
+      "Infiltration": "",
+      "Position": {
+        "x": 26.467,
+        "y": -2.49,
+        "z": -34.414
+      },
+      "Rotation": 82.28416,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 21.1
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "cca16615-941d-4b07-a88f-4064628c1581",
+      "Infiltration": "",
+      "Position": {
+        "x": 35.924,
+        "y": 4.55418539,
+        "z": 35.339
+      },
+      "Rotation": 56.28309,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnBoxParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Size": {
+            "x": 40,
+            "y": 4,
+            "z": 40
+          }
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "d2b48374-53d1-45a7-a3d2-5e1fc58a8499",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -3.612,
+        "y": -3.889,
+        "z": -25.528
+      },
+      "Rotation": 70.69419,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 21.1
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "d2bb26d4-959f-478f-92ad-6adedf2dc512",
+      "Infiltration": "",
+      "Position": {
+        "x": 30.758,
+        "y": 0.26,
+        "z": 15.164
+      },
+      "Rotation": 184.842667,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "d2bc609f-cfaf-421a-8a02-a535e2b25d35",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 52.18,
+        "y": 0.101000071,
+        "z": 23.4599972
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "d2f072c1-9cdc-4d5e-9102-cd77d9edf626",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -33.998188,
+        "y": 1.08018088,
+        "z": 49.9939041
+      },
+      "Rotation": 96.73777,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnBoxParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Size": {
+            "x": 40,
+            "y": 4,
+            "z": 40
+          }
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "d6564897-4b3e-4b7e-9b56-34cb3b9a235d",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -5.769,
+        "y": -3.905,
+        "z": -20.331
+      },
+      "Rotation": 84.01993,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "d685da1e-6b1e-45fb-8e31-e3a42a382fed",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 50.7651863,
+        "y": 0.101000071,
+        "z": 18.0493526
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "d7e47ba9-1862-4070-95de-9a9b2f0e46ff",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 44.33721,
+        "y": 0.102999926,
+        "z": 21.7640057
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "d7fc05a2-a7d9-494a-af5c-e092bb560bb9",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 48.5268364,
+        "y": 0.102999926,
+        "z": 16.6403866
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "da289682-cef5-4ae6-94bb-a2b80705906e",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -35.81619,
+        "y": 1.08018088,
+        "z": 45.3069
+      },
+      "Rotation": 96.73777,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 27
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "de479fb9-789f-499b-ac6b-0530fab5235b",
+      "Infiltration": "",
+      "Position": {
+        "x": -32.087,
+        "y": -2.581647,
+        "z": 29.9733315
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "e0f65b5b-c67b-4e15-a102-f92bbdf95f65",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 68.472,
+        "y": 0.194,
+        "z": -7.34
+      },
+      "Rotation": 184.931458,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "e33e5a4b-4c9e-46f9-b1df-5e9281746f58",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 45.57,
+        "y": 0.05000019,
+        "z": 18.83
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "e5cd7bad-0f60-4cc2-bdd9-8a8943232b01",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -25.718,
+        "y": 1.07,
+        "z": 65.627
+      },
+      "Rotation": 263.74,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "e60d8dce-ee35-4b30-9c3a-afddf4c5445e",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 21.389,
+        "y": -2.61,
+        "z": -1.214
+      },
+      "Rotation": 0,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "efb39132-1eff-4655-8fb0-d795f8f98eb3",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 29.409,
+        "y": 0.256,
+        "z": 20.577
+      },
+      "Rotation": 77.36217,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "f0864450-ffa8-4d7e-aa93-59ea6b218641",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -19.789,
+        "y": 1.07,
+        "z": 66.592
+      },
+      "Rotation": 93.9956055,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "f248ad45-3889-4308-bd40-091b1f6a0492",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -35.4011879,
+        "y": 1.08018088,
+        "z": 46.4789047
+      },
+      "Rotation": 96.73777,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "f3c6d9ee-ca4e-44ca-abdf-0622a8249f1d",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": -24.534,
+        "y": 1.07,
+        "z": 66.641
+      },
+      "Rotation": 263.74,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 41.97
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "f6276290-95d6-4d35-9b1a-53e1db1c08ec",
+      "Infiltration": "",
+      "Position": {
+        "x": 15,
+        "y": 0.148353577,
+        "z": 3.79
+      },
+      "Rotation": 232.964813,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "f8efba5d-56be-4091-b537-c97e88b031f2",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 45.3103752,
+        "y": 0.0729999542,
+        "z": 24.5736217
+      },
+      "Rotation": 269.225647,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "fca84a73-902f-4c3e-b0ce-05f4348d2e12",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 49.05881,
+        "y": 0.11818099,
+        "z": -23.5911
+      },
+      "Rotation": 3.0047307,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 20
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "ff7de580-4ba2-4d00-bff0-13cb6717091c",
+      "Infiltration": "Factory",
+      "Position": {
+        "x": 47.8188133,
+        "y": 0.11818099,
+        "z": -24.2451
+      },
+      "Rotation": 3.0047307,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30.1
+        }
+      },
+      "DelayToCanSpawnSec": 4,
+      "Id": "ff9c3127-2acd-48fe-a635-b1ab99d0bfa7",
+      "Infiltration": "",
+      "Position": {
+        "x": 2.104,
+        "y": 1.10050392,
+        "z": 63.056
+      },
+      "Rotation": 257.797272,
+      "Sides": [
+        "Savage"
+      ]
+    }
+  ],
+  "UnixDateTime": 1636379319,
+  "_Id": "55f2d3fd4bdc2d5f408b4567",
+  "doors": [],
+  "exit_access_time": 60,
+  "exit_count": 3,
+  "exit_time": 1,
+  "exits": [
+    {
+      "Chance": 100,
+      "EntryPoints": "Factory",
+      "ExfiltrationTime": 10,
+      "Id": "",
+      "MaxTime": 0,
+      "MinTime": 0,
+      "Name": "Cellars",
+      "PlayersCount": 0
+    },
+    {
+      "Chance": 100,
+      "EntryPoints": "Factory",
+      "ExfiltrationTime": 10,
+      "Id": "",
+      "MaxTime": 0,
+      "MinTime": 0,
+      "Name": "Gate 3",
+      "PlayersCount": 0
+    },
+    {
+      "Chance": 100,
+      "EntryPoints": "Factory",
+      "ExfiltrationTime": 10,
+      "Id": "",
+      "MaxTime": 0,
+      "MinTime": 0,
+      "Name": "Gate 0",
+      "PlayersCount": 0
+    },
+    {
+      "Chance": 100,
+      "EntryPoints": "Factory",
+      "ExfiltrationTime": 10,
+      "Id": "",
+      "MaxTime": 0,
+      "MinTime": 0,
+      "Name": "Gate m",
+      "PlayersCount": 0
+    }
+  ],
+  "filter_ex": [],
+  "limits": [],
+  "matching_min_seconds": 45,
+  "maxItemCountInLocation": [
+    {
+      "TemplateId": "54009119af1c881c07000029",
+      "Value": 0
+    }
+  ],
+  "sav_summon_seconds": 60,
+  "tmp_location_field_remove_me": 0,
+  "users_gather_seconds": 0,
+  "users_spawn_seconds_n": 120,
+  "users_spawn_seconds_n2": 180,
+  "users_summon_seconds": 0,
+  "waves": [
+    {
+      "BotPreset": "hard",
+      "BotSide": "Savage",
+      "SpawnPoints": "BotZone",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 0,
+      "slots_max": 5,
+      "slots_min": 0,
+      "time_max": 10,
+      "time_min": 1
+  },
+  {
+      "BotPreset": "hard",
+      "BotSide": "Savage",
+      "SpawnPoints": "BotZone",
+      "WildSpawnType": "assault",
+      "isPlayers": false,
+      "number": 1,
+      "slots_max": 5,
+      "slots_min": 0,
+      "time_max": 60,
+      "time_min": 10
+  },
+  {
+      "BotPreset": "hard",
+      "BotSide": "Savage",
+      "SpawnPoints": "BotZone",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 2,
+      "slots_max": 5,
+      "slots_min": 0,
+      "time_max": 120,
+      "time_min": 60
+  },
+  {
+      "BotPreset": "hard",
+      "BotSide": "Savage",
+      "SpawnPoints": "BotZone",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 3,
+      "slots_max": 4,
+      "slots_min": 0,
+      "time_max": 240,
+      "time_min": 120
+  },
+  {
+      "BotPreset": "hard",
+      "BotSide": "Savage",
+      "SpawnPoints": "BotZone",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 4,
+      "slots_max": 3,
+      "slots_min": 0,
+      "time_max": 300,
+      "time_min": 240
+  },
+  {
+      "BotPreset": "hard",
+      "BotSide": "Savage",
+      "SpawnPoints": "BotZone",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 5,
+      "slots_max": 3,
+      "slots_min": 0,
+      "time_max": 510,
+      "time_min": 300
+  },
+  {
+      "BotPreset": "hard",
+      "BotSide": "Savage",
+      "SpawnPoints": "BotZone",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 6,
+      "slots_max": 3,
+      "slots_min": 0,
+      "time_max": 600,
+      "time_min": 520
+  },
+  {
+      "BotPreset": "hard",
+      "BotSide": "Savage",
+      "SpawnPoints": "BotZone",
+      "WildSpawnType": "assault",
+      "isPlayers": false,
+      "number": 7,
+      "slots_max": 2,
+      "slots_min": 0,
+      "time_max": 700,
+      "time_min": 610
+  },
+  {
+      "BotPreset": "hard",
+      "BotSide": "Savage",
+      "SpawnPoints": "",
+      "WildSpawnType": "assault",
+      "isPlayers": false,
+      "number": 8,
+      "slots_max": 2,
+      "slots_min": 0,
+      "time_max": 800,
+      "time_min": 710
+  },
+  {
+      "BotPreset": "hard",
+      "BotSide": "Savage",
+      "SpawnPoints": "",
+      "WildSpawnType": "assault",
+      "isPlayers": false,
+      "number": 9,
+      "slots_max": 2,
+      "slots_min": 0,
+      "time_max": 900,
+      "time_min": 810
+  },
+  {
+      "BotPreset": "hard",
+      "BotSide": "Savage",
+      "SpawnPoints": "",
+      "WildSpawnType": "assault",
+      "isPlayers": false,
+      "number": 10,
+      "slots_max": 5,
+      "slots_min": 0,
+      "time_max": 1000,
+      "time_min": 910
+  }
+  ]
+}

--- a/RNGS_SPAWN_MOD/3.7.6/Standard_vanilla_bosses/tarkovstreets/base.json
+++ b/RNGS_SPAWN_MOD/3.7.6/Standard_vanilla_bosses/tarkovstreets/base.json
@@ -1,0 +1,15022 @@
+{
+  "AccessKeys": [],
+  "AirdropParameters": [
+    {
+      "AirdropPointDeactivateDistance": 100,
+      "MinPlayersCountToSpawnAirdrop": 6,
+      "PlaneAirdropChance": 0.125,
+      "PlaneAirdropCooldownMax": 800,
+      "PlaneAirdropCooldownMin": 700,
+      "PlaneAirdropEnd": 2700,
+      "PlaneAirdropMax": 2,
+      "PlaneAirdropStartMax": 900,
+      "PlaneAirdropStartMin": 300,
+      "UnsuccessfulTryPenalty": 400
+    }
+  ],
+  "Area": 0,
+  "AveragePlayTime": 50,
+  "AveragePlayerLevel": 40,
+  "Banners": [
+    {
+      "id": "5803a58524597710ca36fcb2",
+      "pic": {
+        "path": "CONTENT/banners/banner_terragroup.jpg",
+        "rcid": ""
+      }
+    },
+    {
+      "id": "63a9c1f5662a5b0a2c7fbde5",
+      "pic": {
+        "path": "CONTENT/banners/banner_City_final.jpg",
+        "rcid": ""
+      }
+    },
+    {
+      "id": "64c0acf85174e095610734a0",
+      "pic": {
+        "path": "CONTENT/banners/banner_sherpa.jpg",
+        "rcid": ""
+      }
+    }
+  ],
+  "BossLocationSpawn": [
+    {
+      "BossChance": 35,
+      "BossDifficult": "normal",
+      "BossEscortAmount": "6",
+      "BossEscortDifficult": "normal",
+      "BossEscortType": "followerBoar",
+      "BossName": "bossBoar",
+      "BossPlayer": false,
+      "BossZone": "ZoneCarShowroom",
+      "Delay": 0,
+      "ForceSpawn": false,
+      "IgnoreMaxBots": false,
+      "RandomTimeSpawn": false,
+      "Supports": null,
+      "Time": -1,
+      "TriggerId": "",
+      "TriggerName": ""
+    },
+    {
+      "BossChance": 100,
+      "BossDifficult": "normal",
+      "BossEscortAmount": "1,2",
+      "BossEscortDifficult": "normal",
+      "BossEscortType": "bossBoarSniper",
+      "BossName": "bossBoarSniper",
+      "BossPlayer": false,
+      "BossZone": "ZoneSnipeCarShowroom",
+      "Delay": 0,
+      "ForceSpawn": false,
+      "IgnoreMaxBots": false,
+      "RandomTimeSpawn": false,
+      "Supports": null,
+      "Time": 99999,
+      "TriggerId": "BossBoarBorn",
+      "TriggerName": "botEvent"
+    }
+  ],
+  "BotAssault": 80,
+  "BotEasy": 10,
+  "BotHard": 50,
+  "BotImpossible": 0,
+  "BotLocationModifier": {
+    "AccuracySpeed": 1,
+    "GainSight": 1,
+    "MarksmanAccuratyCoef": 1,
+    "Scattering": 1,
+    "VisibleDistance": 1
+  },
+  "BotMarksman": 20,
+  "BotMax": 21,
+  "BotMaxPlayer": 10,
+  "BotMaxTimePlayer": 1000,
+  "BotNormal": 40,
+  "BotSpawnCountStep": 3,
+  "BotSpawnPeriodCheck": 14,
+  "BotSpawnTimeOffMax": 25,
+  "BotSpawnTimeOffMin": 20,
+  "BotSpawnTimeOnMax": 380,
+  "BotSpawnTimeOnMin": 290,
+  "BotStart": 120,
+  "BotStartPlayer": 20,
+  "BotStop": 1800,
+  "Description": "The downtown Tarkov with banks, malls, hotels and all the other things a striving modern city could have needed.",
+  "DisabledForScav": false,
+  "DisabledScavExits": "",
+  "EnableCoop": true,
+  "Enabled": true,
+  "EscapeTimeLimit": 50,
+  "EscapeTimeLimitCoop": 30,
+  "ExitZones": {
+    "$oid": "5c82534488a45046451a2386"
+  },
+  "GenerateLocalLootCache": true,
+  "GlobalContainerChanceModifier": 1,
+  "GlobalLootChanceModifier": 0.35,
+  "IconX": 600,
+  "IconY": 600,
+  "Id": "TarkovStreets",
+  "Insurance": true,
+  "IsSecret": false,
+  "Locked": false,
+  "Loot": [],
+  "MatchMakerMinPlayersByWaitTime": [
+    {
+      "minPlayers": 12,
+      "time": 60
+    },
+    {
+      "minPlayers": 10,
+      "time": 70
+    },
+    {
+      "minPlayers": 8,
+      "time": 120
+    },
+    {
+      "minPlayers": 7,
+      "time": 180
+    },
+    {
+      "minPlayers": 5,
+      "time": 250
+    },
+    {
+      "minPlayers": 3,
+      "time": 330
+    },
+    {
+      "minPlayers": 1,
+      "time": 420
+    }
+  ],
+  "MaxBotPerZone": 5,
+  "MaxCoopGroup": 20,
+  "MaxDistToFreePoint": 220,
+  "MaxPlayers": 16,
+  "MinDistToExitPoint": 10,
+  "MinDistToFreePoint": 60,
+  "MinMaxBots": [],
+  "MinPlayerLvlAccessKeys": 0,
+  "MinPlayers": 12,
+  "Name": "Streets of Tarkov",
+  "NewSpawn": true,
+  "NonWaveGroupScenario": {
+    "Chance": 50,
+    "Enabled": true,
+    "MaxToBeGroup": 3,
+    "MinToBeGroup": 2
+  },
+  "OcculsionCullingEnabled": false,
+  "OfflineNewSpawn": true,
+  "OfflineOldSpawn": true,
+  "OldSpawn": true,
+  "OpenZones": "ZoneSW01,ZoneConstruction,ZoneCarShowroom,ZoneCinema,ZoneFactory,ZoneHotel_1,ZoneHotel_2,ZoneConcordia_1,ZoneConcordiaParking,ZoneSnipeCinema,ZoneSnipeCarShowroom,ZoneSnipeBuilding,ZoneSnipeSW01",
+  "PlayersRequestCount": -1,
+  "PmcMaxPlayersInGroup": 5,
+  "Preview": {
+    "path": "",
+    "rcid": ""
+  },
+  "RequiredPlayerLevelMax": 100,
+  "RequiredPlayerLevelMin": 0,
+  "Rules": "Normal",
+  "SafeLocation": false,
+  "ScavMaxPlayersInGroup": 4,
+  "Scene": {
+    "path": "maps/city_preset.bundle",
+    "rcid": "city.scenespreset.asset"
+  },
+  "SpawnPointParams": [
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "05381357-3db8-406b-b007-e7290f406ede",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -178.507,
+        "y": 2.451,
+        "z": 415.023
+      },
+      "Rotation": 11.8153534,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "055b9120-abe9-4455-a08b-9841bb1fb1e7",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 184.824,
+        "y": 2.528,
+        "z": 186.987
+      },
+      "Rotation": 24.4516544,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "061e1b50-93bb-4d8e-8a78-79c6d4235b83",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 100.71,
+        "y": -1.854,
+        "z": -162.53
+      },
+      "Rotation": 2.51932168,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW01",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "06645f41-4e96-4b84-9a92-39a7fa89e424",
+      "Infiltration": "",
+      "Position": {
+        "x": 114.480011,
+        "y": 0.920002,
+        "z": 189.07
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "06e00b7c-c4b2-4b41-9b5f-f185b9caf444",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 53.182,
+        "y": 4.531,
+        "z": -138.587
+      },
+      "Rotation": 270.557,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "07beeaca-f6b0-4ff1-ae20-dbbe9cfc0ca4",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 53.22,
+        "y": 4.781,
+        "z": -130.649
+      },
+      "Rotation": 259.938782,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 43
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "08d42d8a-2c4d-4c8d-b23c-3e06b284df92",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 232.64,
+        "y": 3.49,
+        "z": 409.53
+      },
+      "Rotation": 169.7296,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "08f7f64e-6033-4aac-aaab-c731f390fe94",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -118.754,
+        "y": 0.867,
+        "z": 57.728
+      },
+      "Rotation": 351.1806,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConstruction",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 2,
+      "DelayToCanSpawnSec": 40,
+      "Id": "09510846-abde-4c83-8037-8443268a447a",
+      "Infiltration": "",
+      "Position": {
+        "x": 207.14,
+        "y": 4.051,
+        "z": 298.55
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "0a1cae8d-6b53-40d2-a7e5-91771dc05803",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -134.814,
+        "y": 3.058,
+        "z": 399.605
+      },
+      "Rotation": 271.2534,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "0a95f5de-4fed-4aab-8381-b537a5415d88",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -163.933,
+        "y": 3.158,
+        "z": 183.069
+      },
+      "Rotation": 74.27901,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "0afff689-6beb-46a2-aece-4c1380e986fd",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -59.838,
+        "y": 3.202,
+        "z": -147.273
+      },
+      "Rotation": 2.51925588,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 15,
+      "DelayToCanSpawnSec": 40,
+      "Id": "0b1a73ae-2181-4ff5-9e3f-4eebc6cd3983",
+      "Infiltration": "",
+      "Position": {
+        "x": -1.164,
+        "y": -3.71,
+        "z": -4.179001
+      },
+      "Rotation": 162.1,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 6,
+      "DelayToCanSpawnSec": 40,
+      "Id": "0b2ca653-c1f0-4397-af46-95ce58658fa0",
+      "Infiltration": "",
+      "Position": {
+        "x": -84.9,
+        "y": 1.464,
+        "z": 175.6
+      },
+      "Rotation": 162.1,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "0bb11a2f-09a3-4634-905a-10d25db750e7",
+      "Infiltration": "",
+      "Position": {
+        "x": 207.360016,
+        "y": 1.170002,
+        "z": 190.41
+      },
+      "Rotation": 101.827583,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "0e5d78d8-15e0-4d8f-9650-bc88e859a840",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 41.814,
+        "y": 1.197,
+        "z": 62.497
+      },
+      "Rotation": 4.72967052,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "0fc1edd9-6234-49d5-b6f2-fdbca041de7a",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 211.142,
+        "y": -1.221,
+        "z": 341.592
+      },
+      "Rotation": 4.729597,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "10a75815-d786-43e2-9639-6b94071433f8",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 7.45797729,
+        "y": 1.77900016,
+        "z": 153.593964
+      },
+      "Rotation": 57.23363,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCinema",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 4,
+      "DelayToCanSpawnSec": 40,
+      "Id": "1184d04a-dac1-40f3-907f-db6800194b31",
+      "Infiltration": "",
+      "Position": {
+        "x": -194.21,
+        "y": 8.76,
+        "z": 423.09
+      },
+      "Rotation": 90,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "119b220b-ec7f-41a8-bdb2-eeb831e2c17b",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 12.6679993,
+        "y": 2.538,
+        "z": 456.494
+      },
+      "Rotation": 177.4608,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 15,
+      "DelayToCanSpawnSec": 40,
+      "Id": "11ccdd52-c135-48bc-82b3-c288383f1891",
+      "Infiltration": "",
+      "Position": {
+        "x": -50.196,
+        "y": 5.152,
+        "z": -31.695
+      },
+      "Rotation": 8.731616,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "1226cfeb-9685-4cf2-b7ef-1c9cc8095916",
+      "Infiltration": "",
+      "Position": {
+        "x": 236.810013,
+        "y": 0.458999634,
+        "z": 216.9
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCinema",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 4,
+      "DelayToCanSpawnSec": 40,
+      "Id": "128f73cd-2c36-4d32-8846-6fdac1968c1b",
+      "Infiltration": "",
+      "Position": {
+        "x": -192.37,
+        "y": 8.76,
+        "z": 421.58
+      },
+      "Rotation": 90,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "12bb197b-bc6b-449c-9cf1-54ed289a364b",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 228.3,
+        "y": 0.642,
+        "z": 170.736
+      },
+      "Rotation": 263.604279,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 15,
+      "DelayToCanSpawnSec": 40,
+      "Id": "13523e35-3a04-47e5-913a-c54bbf128191",
+      "Infiltration": "",
+      "Position": {
+        "x": -32.96,
+        "y": 0.6080003,
+        "z": -69.863
+      },
+      "Rotation": 8.731616,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "13656e90-49f1-46a7-b873-bc808c6d2652",
+      "Infiltration": "",
+      "Position": {
+        "x": 235.6,
+        "y": 0.458999634,
+        "z": 213.8
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "15d93fe9-dc3b-44a0-9524-a2c372a38a61",
+      "Infiltration": "",
+      "Position": {
+        "x": 58.914,
+        "y": 2.65034533,
+        "z": 324.237
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "1642625e-f60d-48fa-a83a-462639772442",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -59.862,
+        "y": 3.737,
+        "z": -148.574
+      },
+      "Rotation": 2.51925588,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "169a8562-a5fc-48a4-883e-75b34839cc5e",
+      "Infiltration": "",
+      "Position": {
+        "x": 251.63,
+        "y": -1.06999969,
+        "z": 145.41
+      },
+      "Rotation": 101.827583,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "181f7000-df70-4bc7-bff3-a709291c907f",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 5.847992,
+        "y": 1.77900016,
+        "z": 153.694
+      },
+      "Rotation": 57.23363,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 42
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "193e004b-47e0-4a83-9346-c042cfdb0e0d",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 208.555,
+        "y": 3.935,
+        "z": 296.639
+      },
+      "Rotation": 334.7296,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordiaParking",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 9,
+      "DelayToCanSpawnSec": 40,
+      "Id": "19be0a46-a4e4-47b2-add4-a499ffedc605",
+      "Infiltration": "",
+      "Position": {
+        "x": 269.506,
+        "y": -1.227,
+        "z": 379.56
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW01",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "19c4d203-5895-49fa-a91e-67ade5952510",
+      "Infiltration": "",
+      "Position": {
+        "x": 76.02602,
+        "y": -0.629997253,
+        "z": 88.469
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "1a12fe62-5b4c-4569-9442-226daeb537be",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 186.85,
+        "y": 3.529,
+        "z": 460.53
+      },
+      "Rotation": 134.938431,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "1a739b38-2308-4cdf-9997-ed0a40f835d7",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -44.833,
+        "y": 6.678,
+        "z": -114.215
+      },
+      "Rotation": 272.519379,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "1ae5dc66-b54c-4584-bc24-174f5b3194ec",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 15.6880035,
+        "y": 2.538,
+        "z": 455.654022
+      },
+      "Rotation": 177.4608,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "1b431641-ac71-49e5-a807-7988e4799d44",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 209.973,
+        "y": -1.221,
+        "z": 341.66
+      },
+      "Rotation": 4.729597,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW01",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "1b5f67ab-f00f-4f82-b643-533a6ee0aca8",
+      "Infiltration": "",
+      "Position": {
+        "x": 75.69002,
+        "y": 0.5612259,
+        "z": 165.33
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "1b65286c-52e8-48ef-a369-e89bfd0ab95e",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": -7.321991,
+        "y": 1.658,
+        "z": 149.903992
+      },
+      "Rotation": 3.67021,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConstruction",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 2,
+      "DelayToCanSpawnSec": 40,
+      "Id": "1b6daff6-49f0-4f61-93ee-2dfaba6e0969",
+      "Infiltration": "",
+      "Position": {
+        "x": 204.5,
+        "y": 4.051,
+        "z": 297.93
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "1bca5bba-b378-47bb-8ce5-cacc8c5ebcdd",
+      "Infiltration": "",
+      "Position": {
+        "x": 167.700012,
+        "y": -3.73999786,
+        "z": 29.57
+      },
+      "Rotation": 278.614166,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "1c5de52e-7857-41a4-8fa6-a0437a1046c1",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -227.329,
+        "y": 5.26,
+        "z": 277.332
+      },
+      "Rotation": 25.0000076,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "1c9382e9-e618-4ebe-9034-f53406add842",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -58.206,
+        "y": 3.214,
+        "z": -146.784
+      },
+      "Rotation": 2.51925588,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "1cb8c71d-cba3-4641-a415-b1832dd587df",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": -16.305,
+        "y": 2.763,
+        "z": -133.662
+      },
+      "Rotation": 92.51915,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW01",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "1cfdfc07-caca-4ac9-9071-f4b713c659e5",
+      "Infiltration": "",
+      "Position": {
+        "x": 76.42502,
+        "y": -0.629997253,
+        "z": 86.182
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "1da69ad5-800f-4c52-a49c-83ad83567849",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -136.856,
+        "y": 2.565,
+        "z": 399.57
+      },
+      "Rotation": 271.2534,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 15,
+      "DelayToCanSpawnSec": 40,
+      "Id": "1db169f6-83a0-47de-96ed-4a847e05f3af",
+      "Infiltration": "",
+      "Position": {
+        "x": -29.74,
+        "y": 5.15,
+        "z": -64.77
+      },
+      "Rotation": 8.731616,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_2",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 7,
+      "DelayToCanSpawnSec": 40,
+      "Id": "1dd5ae40-6723-4990-9616-bde481d7a12d",
+      "Infiltration": "",
+      "Position": {
+        "x": -74.66,
+        "y": 0.9370003,
+        "z": 75.15
+      },
+      "Rotation": 162.1,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 19,
+      "DelayToCanSpawnSec": 40,
+      "Id": "1f9004a5-0cd6-4c2f-a762-5954978294fa",
+      "Infiltration": "",
+      "Position": {
+        "x": 245.6,
+        "y": -5.68999863,
+        "z": 24.8699989
+      },
+      "Rotation": 278.614166,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "1fa87642-c899-4952-b848-2401a677f05d",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 227.508,
+        "y": 0.642,
+        "z": 171.673
+      },
+      "Rotation": 263.604279,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "205c1c16-f3d6-4504-a1f0-5916e08fe58b",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 232.682,
+        "y": -2.049,
+        "z": -103.148
+      },
+      "Rotation": 4.72974443,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "20a712ad-fd79-4983-89e4-5234075c9638",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 225.906,
+        "y": 0.642,
+        "z": 171.708
+      },
+      "Rotation": 263.604279,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "20bea089-e13b-4eee-8df3-0b1310db37ae",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 60.284,
+        "y": 0.553,
+        "z": 43.093
+      },
+      "Rotation": 22.0116329,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneColumn",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 14,
+      "DelayToCanSpawnSec": 40,
+      "Id": "2112d7ea-fbd3-4bc3-bd4d-72a43ab2d91c",
+      "Infiltration": "",
+      "Position": {
+        "x": -16.872,
+        "y": 2.633,
+        "z": 242.265
+      },
+      "Rotation": 158.789185,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "222800ad-50c8-4c75-b94b-ff1ec3d807d0",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 12.2680054,
+        "y": 2.538,
+        "z": 449.444
+      },
+      "Rotation": 177.4608,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneFactory",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 5,
+      "DelayToCanSpawnSec": 40,
+      "Id": "2534f964-7b45-41dd-9c0b-61df1df3a950",
+      "Infiltration": "",
+      "Position": {
+        "x": -164.56,
+        "y": 2.26,
+        "z": 291.57
+      },
+      "Rotation": 130.584167,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneColumn",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "2592824d-f635-42c7-832c-bcc0c35eddfe",
+      "Infiltration": "",
+      "Position": {
+        "x": -16.71,
+        "y": 2.684,
+        "z": 238.5
+      },
+      "Rotation": 114.231476,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "259e940e-9adc-430c-978b-3e6241e0e52b",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -90.76,
+        "y": 1.313,
+        "z": 66.369
+      },
+      "Rotation": 13.8160019,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneColumn",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 14,
+      "DelayToCanSpawnSec": 40,
+      "Id": "25a1d94e-9e8c-4f52-ba43-61b0360f7681",
+      "Infiltration": "",
+      "Position": {
+        "x": 39.309,
+        "y": 2.816,
+        "z": 220.356
+      },
+      "Rotation": 359.110931,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSnipeCard",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 90
+        }
+      },
+      "CorePointId": 16,
+      "DelayToCanSpawnSec": 40,
+      "Id": "26aca5ba-8735-431a-b615-24e0b7f838c3",
+      "Infiltration": "",
+      "Position": {
+        "x": 65.73,
+        "y": 28.512,
+        "z": -16.0600014
+      },
+      "Rotation": 11.7017088,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "26fca4ae-441f-4c63-b386-eb6f59c81e6e",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -117.481,
+        "y": 0.884,
+        "z": 64.002
+      },
+      "Rotation": 83.99048,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "274a3f4c-d771-4a5a-9a16-40873da3b661",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -35.386,
+        "y": 1.429,
+        "z": 81.787
+      },
+      "Rotation": 94.72958,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordiaParking",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 9,
+      "DelayToCanSpawnSec": 40,
+      "Id": "27706f32-28f0-4d50-9d3c-45fcd6a9841c",
+      "Infiltration": "",
+      "Position": {
+        "x": 208.592,
+        "y": -1.22,
+        "z": 350.427
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "27a58c7b-bbe4-450f-b7fc-9232111ac811",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -134.489,
+        "y": 2.515,
+        "z": 399.622
+      },
+      "Rotation": 271.2534,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "27da6720-9a68-4653-9d42-37044ac627a8",
+      "Infiltration": "",
+      "Position": {
+        "x": 164.554016,
+        "y": 0.544002533,
+        "z": 138.12
+      },
+      "Rotation": 73.40837,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "2860e2ed-22f6-4163-b8e2-d64fcd051a7e",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -176.75,
+        "y": 1.218,
+        "z": 105.23
+      },
+      "Rotation": 94.72969,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "287a00e5-afa8-4255-991d-598e2cc0f455",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 231.865,
+        "y": -2.049,
+        "z": -106.136
+      },
+      "Rotation": 4.72974443,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "287bf35f-5cdc-44dc-97b6-c035d5054bfa",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 6.354004,
+        "y": 1.77900016,
+        "z": 158.00296
+      },
+      "Rotation": 57.23363,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "292c7de6-8bd9-4ee8-969e-c3e1f0f56985",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 41.778,
+        "y": 1.197,
+        "z": 66.538
+      },
+      "Rotation": 287.434448,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordia_1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 8,
+      "DelayToCanSpawnSec": 40,
+      "Id": "29811563-ab9e-4f98-8f1f-d761e2e91b72",
+      "Infiltration": "",
+      "Position": {
+        "x": 271.1,
+        "y": 3.526,
+        "z": 374.04
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 34
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "2a0f649a-ad74-43ae-a6a9-26dd04f64eb0",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -205.115,
+        "y": 3.367,
+        "z": 182.111
+      },
+      "Rotation": 4.729717,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "2a63de9c-7537-41ca-9670-de45fba8892c",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 187.061,
+        "y": 1.574,
+        "z": 189.557
+      },
+      "Rotation": 24.4516544,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSnipeCarShowroom",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 90
+        }
+      },
+      "CorePointId": 11,
+      "DelayToCanSpawnSec": 40,
+      "Id": "2abb0c15-d068-468a-9b7a-78d4983bc277",
+      "Infiltration": "",
+      "Position": {
+        "x": 55.02,
+        "y": 11.9036674,
+        "z": 297.38
+      },
+      "Rotation": 90,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "2b1b27d7-a1c0-441b-bd2c-4f781c5a71f2",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -33.939,
+        "y": 1.429,
+        "z": 82.052
+      },
+      "Rotation": 94.72958,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 2,
+      "DelayToCanSpawnSec": 40,
+      "Id": "2b20029f-4ecf-42c4-95cb-9485b26f8954",
+      "Infiltration": "",
+      "Position": {
+        "x": 142.866,
+        "y": 3.622,
+        "z": 363.484
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "2cd8477f-c239-49a4-bba0-0cf266c5a806",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -99.794,
+        "y": 1.313,
+        "z": 70.348
+      },
+      "Rotation": 323.630524,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 6,
+      "DelayToCanSpawnSec": 40,
+      "Id": "2d3db7b9-4c70-4ccc-9654-98577c10587c",
+      "Infiltration": "",
+      "Position": {
+        "x": -69.316,
+        "y": 1.464,
+        "z": 156.097
+      },
+      "Rotation": 331.5,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "2e02fd39-ee4a-4c26-bb44-12324b433a02",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": -7.441986,
+        "y": 1.65800035,
+        "z": 146.70401
+      },
+      "Rotation": 3.67021,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "2e7b1c7a-a66e-4c90-9937-53a61ca5e7da",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -179.339,
+        "y": 2.451,
+        "z": 416.352
+      },
+      "Rotation": 11.8153534,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "2e904d20-0a47-458c-92e2-6f51d7b600dc",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 261.511,
+        "y": -5.94,
+        "z": 49.977
+      },
+      "Rotation": 319.729767,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordiaParking",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 9,
+      "DelayToCanSpawnSec": 40,
+      "Id": "3153c2aa-0d0a-41a0-bd5b-9b1a9c290ad7",
+      "Infiltration": "",
+      "Position": {
+        "x": 259.267,
+        "y": -1.227,
+        "z": 358.498
+      },
+      "Rotation": 180,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "31802d49-5363-437c-86d4-bdf80b7d0e94",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -176.596,
+        "y": 2.455,
+        "z": 466.984
+      },
+      "Rotation": 181.253433,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneColumn",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 14,
+      "DelayToCanSpawnSec": 40,
+      "Id": "31da51b5-0808-4dd4-a4e6-35399322cef8",
+      "Infiltration": "",
+      "Position": {
+        "x": 39.23,
+        "y": 2.872,
+        "z": 222.293
+      },
+      "Rotation": 359.110931,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 15,
+      "DelayToCanSpawnSec": 40,
+      "Id": "31ebf7ee-a9ab-40c9-9e24-9ed91d8da2f5",
+      "Infiltration": "",
+      "Position": {
+        "x": -36.052,
+        "y": 5.22,
+        "z": -64.392
+      },
+      "Rotation": 8.731616,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "324de29c-ed55-45f0-8b62-5a6f125d89ee",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 271.36,
+        "y": -1.16,
+        "z": 376.28
+      },
+      "Rotation": 334.7296,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "333d8134-55fa-4556-9214-59703d6fd4cf",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -111.692,
+        "y": 0.659,
+        "z": -28.424
+      },
+      "Rotation": 107.519135,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 3,
+      "DelayToCanSpawnSec": 40,
+      "Id": "33b14947-807c-4859-b624-2a5a9bf52642",
+      "Infiltration": "",
+      "Position": {
+        "x": 82.266,
+        "y": 2.791,
+        "z": 266.358
+      },
+      "Rotation": 322.1663,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "33d131d6-6d76-4aec-bb47-0836c511f5dc",
+      "Infiltration": "",
+      "Position": {
+        "x": 203.780014,
+        "y": 1.170002,
+        "z": 190.65
+      },
+      "Rotation": 101.827583,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCard1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 19,
+      "DelayToCanSpawnSec": 40,
+      "Id": "34e1c00b-b8c8-4785-a3ea-eb8b126ccec2",
+      "Infiltration": "",
+      "Position": {
+        "x": 140.690018,
+        "y": -1.41999817,
+        "z": -51.709
+      },
+      "Rotation": 329.075928,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 34
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "34f4b186-867c-431d-b706-d4114867c969",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -203.631,
+        "y": 3.367,
+        "z": 180.776
+      },
+      "Rotation": 4.729717,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSnipeCard",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 90
+        }
+      },
+      "CorePointId": 16,
+      "DelayToCanSpawnSec": 40,
+      "Id": "350d3a45-3f46-469f-bbc3-198febc34c0e",
+      "Infiltration": "",
+      "Position": {
+        "x": 41.18,
+        "y": 28.512,
+        "z": -20.71
+      },
+      "Rotation": 11.7017088,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "3563d32b-aae5-4f04-a95d-36d8455b42f0",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 234.745,
+        "y": -2.049,
+        "z": -103.385
+      },
+      "Rotation": 4.72974443,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCard1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 19,
+      "DelayToCanSpawnSec": 40,
+      "Id": "358d98fd-ed88-4bc7-9262-7a2b0b30a6c5",
+      "Infiltration": "",
+      "Position": {
+        "x": 126.700012,
+        "y": -1.41999817,
+        "z": -27.66
+      },
+      "Rotation": 64.55609,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "35c84f0b-bdc1-4499-814d-f904a9dfe896",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 102.07,
+        "y": -1.854,
+        "z": -158.58
+      },
+      "Rotation": 2.51932168,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneFactory",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 5,
+      "DelayToCanSpawnSec": 40,
+      "Id": "35fccda0-0247-46f3-94df-76098e9a5dcd",
+      "Infiltration": "",
+      "Position": {
+        "x": -105.041,
+        "y": 2.32,
+        "z": 267.041016
+      },
+      "Rotation": 90,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "379f1724-3244-4a26-a604-857607bab059",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -150.644,
+        "y": 0.65,
+        "z": -63.383
+      },
+      "Rotation": 15.3466482,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordiaParking",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 9,
+      "DelayToCanSpawnSec": 40,
+      "Id": "383076ad-7326-462b-bfea-185955826c80",
+      "Infiltration": "",
+      "Position": {
+        "x": 269.852,
+        "y": -1.227,
+        "z": 381.269
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCinema",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 4,
+      "DelayToCanSpawnSec": 40,
+      "Id": "3921f8b5-6d3c-4dc3-ac17-d5d702923a8f",
+      "Infiltration": "",
+      "Position": {
+        "x": -135.394,
+        "y": 2.545,
+        "z": 399.657
+      },
+      "Rotation": 180,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "3928558f-893e-4c30-a981-1a93e4ba9468",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -182.94,
+        "y": 2.41,
+        "z": 413.56
+      },
+      "Rotation": 11.8153534,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "39637b62-6c87-4fee-bc32-446b3e76ad65",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -152.333,
+        "y": 0.736,
+        "z": -66.574
+      },
+      "Rotation": 15.3466482,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_2",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 7,
+      "DelayToCanSpawnSec": 40,
+      "Id": "3a281c99-5e96-4f0f-b032-8efc6821ccd0",
+      "Infiltration": "",
+      "Position": {
+        "x": -76.42,
+        "y": 0.9370003,
+        "z": 76.47
+      },
+      "Rotation": 162.1,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "3a49af12-a9d4-44fb-b6e1-241cfd48661f",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 175.964,
+        "y": 3.093,
+        "z": 234.797
+      },
+      "Rotation": 356.824432,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "3a4a68fa-218b-45f4-a54d-c5d5acf527ec",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 120.063,
+        "y": 0.503,
+        "z": 127.036
+      },
+      "Rotation": 279.4518,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "3b54601a-2e4b-4991-988e-962f1ee45668",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 1.82800293,
+        "y": 1.77900016,
+        "z": 155.083984
+      },
+      "Rotation": 57.23363,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneFactory",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 5,
+      "DelayToCanSpawnSec": 40,
+      "Id": "3b8e4422-13da-41b3-a2e1-0e38feac3feb",
+      "Infiltration": "",
+      "Position": {
+        "x": -162,
+        "y": 2.26,
+        "z": 289.52
+      },
+      "Rotation": 130.584167,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "3c5202ab-9df1-464d-bceb-f7b0c94978b3",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -192.658,
+        "y": 4.993,
+        "z": 386.326
+      },
+      "Rotation": 190.496658,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_2",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 7,
+      "DelayToCanSpawnSec": 40,
+      "Id": "3c6ca872-16c6-4adb-8252-b516633f5cdc",
+      "Infiltration": "",
+      "Position": {
+        "x": -80.18,
+        "y": 0.9370003,
+        "z": 74.08
+      },
+      "Rotation": 162.1,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneFactory",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 5,
+      "DelayToCanSpawnSec": 40,
+      "Id": "3c6e3d41-a66f-4ed4-9c9c-1869c1564d4d",
+      "Infiltration": "",
+      "Position": {
+        "x": -171.35,
+        "y": 2.36,
+        "z": 285.08
+      },
+      "Rotation": 130.584167,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "3d6f0b05-6fa2-414a-8e6a-1c725ee7c98b",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 52.732,
+        "y": 4.531,
+        "z": -135.649
+      },
+      "Rotation": 269.1392,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "3d9fb92f-160b-499a-a926-fc76babd067b",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 110.69,
+        "y": -2.132,
+        "z": 54.35
+      },
+      "Rotation": 109.729546,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "3da963bd-5ff6-4d70-ab3c-50dbc5291d93",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -50.879,
+        "y": 0.668,
+        "z": -67.271
+      },
+      "Rotation": 107.519135,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "3e99040a-66f7-415b-9a85-8df0896532d4",
+      "Infiltration": "",
+      "Position": {
+        "x": 251.740021,
+        "y": -1.06999969,
+        "z": 148.39
+      },
+      "Rotation": 101.827583,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 15,
+      "DelayToCanSpawnSec": 40,
+      "Id": "3ee456f1-df10-40f4-a6ab-e26706d3dc51",
+      "Infiltration": "",
+      "Position": {
+        "x": -30.119,
+        "y": 0.691,
+        "z": -63.183
+      },
+      "Rotation": 8.731616,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "3f2579e6-c7a4-46c3-8b3f-c5e46b2f2179",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 185.6,
+        "y": 3.529,
+        "z": 459.37
+      },
+      "Rotation": 134.938431,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "40456b8a-17a5-48ec-acfc-fcaccffbb369",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -235.154,
+        "y": 2.846,
+        "z": 345.06
+      },
+      "Rotation": 16.7069,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "415f3cfd-a781-4cce-af45-a6e5e540c2d8",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 99.35,
+        "y": 2.76,
+        "z": 446.78
+      },
+      "Rotation": 169.729568,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_2",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 7,
+      "DelayToCanSpawnSec": 40,
+      "Id": "417cf88b-8b89-4c07-ad22-19ae30181e1e",
+      "Infiltration": "",
+      "Position": {
+        "x": -109.617,
+        "y": 1.464,
+        "z": 73.128
+      },
+      "Rotation": 162.1,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "42b3280a-3239-4464-a32d-cab3eb7d6653",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -34.426,
+        "y": 1.429,
+        "z": 83.728
+      },
+      "Rotation": 94.72958,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "434372f3-b06c-4ff2-bddd-ea5c49e64980",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 155.767,
+        "y": 3.624,
+        "z": 428.614
+      },
+      "Rotation": 169.729568,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "436921b9-0a30-441a-b000-75f4ec52d4ba",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -107.38,
+        "y": 1.313,
+        "z": 71.9
+      },
+      "Rotation": 347.919159,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "43c7fa07-b021-4598-a78d-f5ec7e6fc275",
+      "Infiltration": "",
+      "Position": {
+        "x": 260.210022,
+        "y": -1.199997,
+        "z": 130.040009
+      },
+      "Rotation": 101.827583,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordia_1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 8,
+      "DelayToCanSpawnSec": 40,
+      "Id": "4469c4a1-556f-465f-9809-56ee1750ea7e",
+      "Infiltration": "",
+      "Position": {
+        "x": 204.66,
+        "y": 3.545,
+        "z": 404.31
+      },
+      "Rotation": 90,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSnipeStilo",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 90
+        }
+      },
+      "CorePointId": 18,
+      "DelayToCanSpawnSec": 40,
+      "Id": "44ea9b1d-052b-47cc-9f42-b8cf51fbbfa9",
+      "Infiltration": "",
+      "Position": {
+        "x": -132.87,
+        "y": 14.9,
+        "z": -10.3600006
+      },
+      "Rotation": 11.7017088,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "4598a010-a486-47b8-8242-fd738fccb250",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 272.733,
+        "y": -4.431,
+        "z": 89.033
+      },
+      "Rotation": 93.71277,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "459dcb35-edf8-4a0f-b8c3-292aed6e54f8",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -242.312,
+        "y": 3.685,
+        "z": 242.94
+      },
+      "Rotation": 205,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 6,
+      "DelayToCanSpawnSec": 40,
+      "Id": "45d9b42b-28a4-4bb6-abe2-c24545223f8f",
+      "Infiltration": "",
+      "Position": {
+        "x": -70.471,
+        "y": 1.464,
+        "z": 152.372009
+      },
+      "Rotation": 331.5,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "45dad431-3cf2-4f42-8a9f-8b1ea826ea7d",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 51.292,
+        "y": 0.553,
+        "z": 44.094
+      },
+      "Rotation": 109.729546,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "45ee04b7-c90a-45d9-a774-a2462823e1d9",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 45.792,
+        "y": 2.717,
+        "z": 417.082
+      },
+      "Rotation": 241.253387,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "461b6342-cc1c-4217-8d98-ddd3f56471ba",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 157,
+        "y": 3.624,
+        "z": 430.76
+      },
+      "Rotation": 169.729568,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "489874fa-2e4b-4351-b54a-40785d13404f",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 186.511,
+        "y": 1.574,
+        "z": 188.445
+      },
+      "Rotation": 24.4516544,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "491a4b6a-c73d-40da-a516-6dd86803b95c",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 118.61,
+        "y": 0.503,
+        "z": 127.434
+      },
+      "Rotation": 279.4518,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "4954677b-e5db-40c3-a31a-991cf0078667",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 186.79,
+        "y": 3.529,
+        "z": 454.4
+      },
+      "Rotation": 134.938431,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "49dbe3ee-602c-41ad-977b-03391cb6ef85",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -106.422,
+        "y": 0.662,
+        "z": -29.223
+      },
+      "Rotation": 107.519135,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "4a2321cc-5cff-43fb-9fd9-8503c30409b5",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -231.985,
+        "y": 2.196,
+        "z": 342.49
+      },
+      "Rotation": 340.000031,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCard1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 7,
+      "DelayToCanSpawnSec": 40,
+      "Id": "4aeb1502-98fc-4f3c-a7e9-59dfc791e721",
+      "Infiltration": "",
+      "Position": {
+        "x": 43.5800171,
+        "y": 0.270000458,
+        "z": -43.65
+      },
+      "Rotation": 309.888733,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "4afab3b8-1bf3-4a60-add4-c35c282330de",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -243.129,
+        "y": 3.43,
+        "z": 240.565
+      },
+      "Rotation": 205,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "4be30299-8bd5-40a7-8ddb-567fcf24fe8e",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": -10.37,
+        "y": 2.763,
+        "z": -135.41
+      },
+      "Rotation": 92.51915,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "4da35c04-b1ba-4958-b3df-284fe60599c5",
+      "Infiltration": "",
+      "Position": {
+        "x": 170.02002,
+        "y": -3.73999786,
+        "z": 30.06
+      },
+      "Rotation": 278.614166,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 19,
+      "DelayToCanSpawnSec": 40,
+      "Id": "4de9c24c-c84d-4679-88fd-3cc1c3b70f8f",
+      "Infiltration": "",
+      "Position": {
+        "x": 244.650009,
+        "y": -5.369999,
+        "z": 28.72
+      },
+      "Rotation": 278.614166,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "4e394534-0f48-48d1-9eea-9f220a71ab7c",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -180.504,
+        "y": 2.451,
+        "z": 419.05
+      },
+      "Rotation": 11.8153534,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "4e6a55b9-afc8-43a5-8829-a975360bdd1d",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 233.368,
+        "y": -2.049,
+        "z": -107.123
+      },
+      "Rotation": 4.72974443,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "4e876370-2396-4517-81c1-c535811d18e0",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": -2.321991,
+        "y": 1.65800035,
+        "z": 147.134
+      },
+      "Rotation": 3.67021,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 43
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "4eac1ca9-b5e9-4152-8a37-1b6a9ceb31c0",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 227.6,
+        "y": 3.351,
+        "z": 410.72
+      },
+      "Rotation": 169.7296,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "4ef9cea7-5a05-48f7-a2f9-ec3d8c293e46",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -175.222,
+        "y": 2.455,
+        "z": 468.656
+      },
+      "Rotation": 181.253433,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "4f0da6f6-eec6-4ed9-9071-620f980f7424",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -104.987,
+        "y": 1.313,
+        "z": 71.19
+      },
+      "Rotation": 336.3428,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "4f151837-42df-4901-a690-eb2a0e8da35b",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -152.769,
+        "y": 9.669,
+        "z": -26.856
+      },
+      "Rotation": 2.51923227,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "4f865c11-d533-4fce-9833-fe41a6cb52af",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 7.097992,
+        "y": 1.80700016,
+        "z": 159.374
+      },
+      "Rotation": 335.685852,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "4fa6a8fd-fbae-4fb9-8a46-2fd88ac12e03",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -150.592,
+        "y": 9.644,
+        "z": -23.594
+      },
+      "Rotation": 2.51923227,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "4fb0d413-cf19-4580-8217-b2d6ca431e91",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 7.289978,
+        "y": 1.77900016,
+        "z": 160.726959
+      },
+      "Rotation": 57.23363,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 3,
+      "DelayToCanSpawnSec": 40,
+      "Id": "4fcde5e7-1138-4ab0-8e90-9e8c3d10a212",
+      "Infiltration": "",
+      "Position": {
+        "x": 101.45,
+        "y": 4.99,
+        "z": 312.85
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 43
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "507e4e1d-a245-4f88-9f2b-6050cd4a6c38",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 231.32,
+        "y": 3.49,
+        "z": 410.43
+      },
+      "Rotation": 169.7296,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "513389c0-537c-4b78-8605-eb3a3bedc851",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -47.652,
+        "y": 0.668,
+        "z": -65.516
+      },
+      "Rotation": 107.519135,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneColumn",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "51a30b1a-f6ba-456f-aeec-8f11af3d4ab4",
+      "Infiltration": "",
+      "Position": {
+        "x": -15.846,
+        "y": 2.633,
+        "z": 232.6
+      },
+      "Rotation": 114.231476,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "51d31613-2013-4a87-911f-5b2fb4d44c25",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 44.472,
+        "y": 2.717,
+        "z": 414.922
+      },
+      "Rotation": 241.253387,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "523ddb61-fa1c-460d-be68-4f7638f6d80d",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 244.71,
+        "y": -3.21,
+        "z": -36.95
+      },
+      "Rotation": 259.729858,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordia_1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 8,
+      "DelayToCanSpawnSec": 40,
+      "Id": "5270edf8-cf70-4cd7-90fc-49468210127f",
+      "Infiltration": "",
+      "Position": {
+        "x": 200.801,
+        "y": 3.545,
+        "z": 405.031
+      },
+      "Rotation": 90,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "5419341d-08ed-4bee-bad9-a964af07ac11",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -234.277,
+        "y": 2.196,
+        "z": 342.105
+      },
+      "Rotation": 16.7069,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "55969eb0-e827-41db-974a-cd045ff773b4",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 175.713,
+        "y": 3.172,
+        "z": 236.73
+      },
+      "Rotation": 356.824432,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 15,
+      "DelayToCanSpawnSec": 40,
+      "Id": "55b5980e-aa6d-43ac-8048-d468a88f936f",
+      "Infiltration": "",
+      "Position": {
+        "x": -31.626,
+        "y": 0.615,
+        "z": -59.596
+      },
+      "Rotation": 8.731616,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "566d2f6b-240c-47b2-a985-0868f5a20b38",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -48.546,
+        "y": 0.668,
+        "z": -67.733
+      },
+      "Rotation": 107.519135,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "56ae82fe-7073-45e7-82bf-a94494b5a509",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 179.062,
+        "y": 3.048,
+        "z": 233.031
+      },
+      "Rotation": 356.824432,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "57447dd0-17ce-427b-af71-7d4ecfb2fda5",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -92.62,
+        "y": 1.414,
+        "z": 124.36
+      },
+      "Rotation": 184.72963,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCard1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 19,
+      "DelayToCanSpawnSec": 40,
+      "Id": "575d2aa4-4e0c-468b-9271-f13239107f34",
+      "Infiltration": "",
+      "Position": {
+        "x": 143.030014,
+        "y": -1.41999817,
+        "z": -36.03
+      },
+      "Rotation": 329.075928,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 3,
+      "DelayToCanSpawnSec": 40,
+      "Id": "578acd5d-81d1-4066-910e-59a66e37ff76",
+      "Infiltration": "",
+      "Position": {
+        "x": 89.824,
+        "y": 2.6838336,
+        "z": 314.917
+      },
+      "Rotation": 187.999588,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "587f4c37-b43e-4319-a238-f394bf59609d",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -226.569,
+        "y": 5.26,
+        "z": 279.065
+      },
+      "Rotation": 25.0000076,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "5b161871-7fe0-4764-925b-75a5d9320859",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": -31.202,
+        "y": 2.615,
+        "z": 465.022
+      },
+      "Rotation": 181.253433,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneColumn",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 14,
+      "DelayToCanSpawnSec": 40,
+      "Id": "5c04bcce-321c-4fd8-bcd1-b4e206e27891",
+      "Infiltration": "",
+      "Position": {
+        "x": 39.257,
+        "y": 2.829,
+        "z": 200.375
+      },
+      "Rotation": 359.110931,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 6,
+      "DelayToCanSpawnSec": 40,
+      "Id": "5c87fb9e-e9df-4ab7-814b-daca25a31edf",
+      "Infiltration": "",
+      "Position": {
+        "x": -87.68,
+        "y": 1.464,
+        "z": 178.296
+      },
+      "Rotation": 162.1,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "5caf5e1b-0113-41fc-9867-007e37ffe906",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 1.6579895,
+        "y": 1.77900016,
+        "z": 153.353973
+      },
+      "Rotation": 57.23363,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "5ce456df-113c-4bc8-952a-9211fc226caf",
+      "Infiltration": "",
+      "Position": {
+        "x": 165.540009,
+        "y": -1.27999878,
+        "z": 106.77
+      },
+      "Rotation": 278.614166,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "5cfd77db-4ab6-45ec-a4d4-a4a30c9e75ce",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 211.905,
+        "y": -0.33,
+        "z": 343.2
+      },
+      "Rotation": 4.729597,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCard1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 19,
+      "DelayToCanSpawnSec": 40,
+      "Id": "5e10035a-c797-41f6-bfbf-f758cd8f2d17",
+      "Infiltration": "",
+      "Position": {
+        "x": 137.993011,
+        "y": -1.41999817,
+        "z": -55.086
+      },
+      "Rotation": 329.075928,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "5e92a302-e46c-4acc-adc8-b349b40b5fd7",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 272.018,
+        "y": -1.16,
+        "z": 375.369
+      },
+      "Rotation": 334.7296,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "603355cd-6997-44d1-bca2-c52368a4a603",
+      "Infiltration": "",
+      "Position": {
+        "x": 189.16,
+        "y": 1.670002,
+        "z": 206.87
+      },
+      "Rotation": 101.827583,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "60ac962f-60e7-4049-b52b-bbcc48bd2a86",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 257.34,
+        "y": -5.94,
+        "z": 50.955
+      },
+      "Rotation": 319.729767,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "61264e7e-0ca3-42ea-8537-fa9b655df5be",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 170.335,
+        "y": -1.451,
+        "z": -129.286
+      },
+      "Rotation": 268.9683,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "61aba24c-79d9-445f-8a1c-f887b36a8417",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 8.807999,
+        "y": 2.36800027,
+        "z": 455.754
+      },
+      "Rotation": 177.4608,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConstruction",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 2,
+      "DelayToCanSpawnSec": 40,
+      "Id": "61bb936f-91b0-4071-9efc-6eca425f32aa",
+      "Infiltration": "",
+      "Position": {
+        "x": 204.58,
+        "y": 6.91,
+        "z": 297.1
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 15,
+      "DelayToCanSpawnSec": 40,
+      "Id": "6207d239-8931-43b0-96ac-44517f3c080b",
+      "Infiltration": "",
+      "Position": {
+        "x": -3.191,
+        "y": -3.71,
+        "z": -6.13499832
+      },
+      "Rotation": 162.1,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "6255df32-b929-4e02-8db9-ddf69e716491",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -231.978,
+        "y": 2.312,
+        "z": 344.996
+      },
+      "Rotation": 16.7069,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "62f5b14d-cb51-4529-b572-f5a8f5815bb5",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 9.936005,
+        "y": 1.80700016,
+        "z": 160.441986
+      },
+      "Rotation": 335.685852,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "6334d0e4-3651-4ed3-ba11-5dcb4a8ac4e6",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -176.32,
+        "y": 1.218,
+        "z": 106.89
+      },
+      "Rotation": 94.72969,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 2,
+      "DelayToCanSpawnSec": 40,
+      "Id": "63631f94-0321-4d0f-bd7b-8224eeeb4192",
+      "Infiltration": "",
+      "Position": {
+        "x": 143.03,
+        "y": 3.52,
+        "z": 359.66
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 42
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "6425842e-d951-4538-8b44-ab6fccfae4c4",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 205.631,
+        "y": 3.935,
+        "z": 296.404
+      },
+      "Rotation": 334.7296,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "65894af8-198d-4e4a-ac91-315d3aaf72d4",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -135.79,
+        "y": 2.34,
+        "z": 401.49
+      },
+      "Rotation": 271.2534,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCard1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 19,
+      "DelayToCanSpawnSec": 40,
+      "Id": "66b99517-10bc-443b-a790-c7668738bd63",
+      "Infiltration": "",
+      "Position": {
+        "x": 144.930008,
+        "y": -1.41999817,
+        "z": -42.8000031
+      },
+      "Rotation": 329.075928,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "677581fc-5c9f-4e13-913d-e32798dfd61c",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 12.1080017,
+        "y": 2.538,
+        "z": 450.534027
+      },
+      "Rotation": 177.4608,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "67e51e91-d041-48e6-aabb-9786ff1e8b3b",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -81.02,
+        "y": 1.313,
+        "z": 64.16
+      },
+      "Rotation": 1.72222173,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "69050d45-9c16-42cb-8c05-c02fc582ccce",
+      "Infiltration": "",
+      "Position": {
+        "x": 224.564011,
+        "y": 0.5250015,
+        "z": 182.244
+      },
+      "Rotation": 101.827583,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 42
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "699750da-15c5-4b86-9997-7dc18be81b1c",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 209.839,
+        "y": 3.935,
+        "z": 297.28
+      },
+      "Rotation": 334.7296,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "6b002dfe-a3c6-4a6a-8a38-0b8c7953d574",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -92.351,
+        "y": 1.414,
+        "z": 126.507
+      },
+      "Rotation": 184.72963,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 2,
+      "DelayToCanSpawnSec": 40,
+      "Id": "6b46a1d6-60f8-4f42-bae7-6fd985e703a8",
+      "Infiltration": "",
+      "Position": {
+        "x": 147.22,
+        "y": 3.531,
+        "z": 358
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "6b6de2c9-883b-4eeb-9044-875abe5dfdd4",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 104.1,
+        "y": -2.04,
+        "z": 58.81
+      },
+      "Rotation": 226.20929,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSnipeStilo",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 90
+        }
+      },
+      "CorePointId": 18,
+      "DelayToCanSpawnSec": 40,
+      "Id": "6c2707ae-621f-4525-abef-f2ce4eb9c31e",
+      "Infiltration": "",
+      "Position": {
+        "x": -147.78,
+        "y": 14.9,
+        "z": -7.22999954
+      },
+      "Rotation": 11.7017088,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "6c27f4e5-06ad-4932-a056-b0c2c343d498",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 258.622,
+        "y": -5.94,
+        "z": 48.843
+      },
+      "Rotation": 319.729767,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "6c90c26e-cfca-4e75-986b-de60d0c7459c",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 211.97,
+        "y": 0.444,
+        "z": 345.289
+      },
+      "Rotation": 4.729597,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "6cfbccb6-7a27-4476-897d-049e95a5386b",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 274.053,
+        "y": 4.782,
+        "z": 518.326
+      },
+      "Rotation": 236.6915,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_2",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 7,
+      "DelayToCanSpawnSec": 40,
+      "Id": "6d018e69-d1b4-411f-81bc-40c2b58beeda",
+      "Infiltration": "",
+      "Position": {
+        "x": -96.1,
+        "y": 0.9370003,
+        "z": 87
+      },
+      "Rotation": 162.1,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "6d99aad4-c884-48fe-ac03-6edbbdc51052",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 106.65,
+        "y": -1.854,
+        "z": -162.6
+      },
+      "Rotation": 2.51932168,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "6dc4485e-2d62-46f8-b613-6c2881561d96",
+      "Infiltration": "",
+      "Position": {
+        "x": 188.930023,
+        "y": 0.6000023,
+        "z": 195.19
+      },
+      "Rotation": 101.827583,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConstruction",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 2,
+      "DelayToCanSpawnSec": 40,
+      "Id": "6dff18c6-81f3-4bfc-81f1-1303951cb66e",
+      "Infiltration": "",
+      "Position": {
+        "x": 215.331,
+        "y": 3.37095356,
+        "z": 331.588
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "6e1e5bab-a851-47da-8e1f-6245213bf837",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 116.436,
+        "y": 0.53,
+        "z": 128.073
+      },
+      "Rotation": 279.4518,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "6e3ad315-21c1-4816-84f5-e6d5ad0568af",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 10.3880005,
+        "y": 2.538,
+        "z": 457.094025
+      },
+      "Rotation": 177.4608,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "6ec418fb-b0cc-48e5-9435-6fdd642a23a6",
+      "Infiltration": "",
+      "Position": {
+        "x": 258.721,
+        "y": -5.336998,
+        "z": 77.856
+      },
+      "Rotation": 278.614166,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "6f685b3e-cf6a-4e34-8a6e-c5fee3b1308d",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -157.981,
+        "y": 9.684,
+        "z": -26.729
+      },
+      "Rotation": 2.51923227,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "6fa19d8b-0a96-4aa3-8441-9d9d66649d3c",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -195.373,
+        "y": 4.992,
+        "z": 384.652
+      },
+      "Rotation": 190.496658,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "71098951-d846-4225-a9bc-6b418505bdcc",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 177.294,
+        "y": 3.093,
+        "z": 234.762
+      },
+      "Rotation": 356.824432,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "7358f6b2-61ea-47db-8b99-e8ed4df5f93c",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -161.686,
+        "y": 3.221,
+        "z": 180.655
+      },
+      "Rotation": 74.27901,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 3,
+      "DelayToCanSpawnSec": 40,
+      "Id": "73adcb52-871b-4db4-9d15-a1933c74d25a",
+      "Infiltration": "",
+      "Position": {
+        "x": 100.996,
+        "y": 2.6838336,
+        "z": 271.171021
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "7433262f-ef82-43b6-b06e-a8c77ba35fd8",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 211.022,
+        "y": 0.465,
+        "z": 346.075
+      },
+      "Rotation": 272.480042,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "7476377d-3918-48b1-9a1c-e5b54b54b1ef",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -225.555,
+        "y": 5.226,
+        "z": 282.178
+      },
+      "Rotation": 25.0000076,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordiaParking",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 9,
+      "DelayToCanSpawnSec": 40,
+      "Id": "74da4f5f-d920-4e4b-b968-1a37a9f06402",
+      "Infiltration": "",
+      "Position": {
+        "x": 210.467,
+        "y": -1.22,
+        "z": 351.635
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "74effe05-4c97-43b5-aabe-7d21e692d290",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -243.08,
+        "y": 3.685,
+        "z": 243.479
+      },
+      "Rotation": 205,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "751ed8cb-d9c5-4c3a-ad31-7ae979f66316",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": -4.18898,
+        "y": 1.79799974,
+        "z": 148.65
+      },
+      "Rotation": 3.67021,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "75be936b-36ee-4cc4-8172-ef1298934a7d",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": -14.886,
+        "y": 2.763,
+        "z": -139.338
+      },
+      "Rotation": 92.51915,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "75ce069c-ef5a-4ae0-b129-7242d1464303",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -162.757,
+        "y": 3.221,
+        "z": 177.965
+      },
+      "Rotation": 4.72961473,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 6,
+      "DelayToCanSpawnSec": 40,
+      "Id": "75fa3845-7307-4d5c-800e-a6829906d87b",
+      "Infiltration": "",
+      "Position": {
+        "x": -70.735,
+        "y": 1.464,
+        "z": 154.221008
+      },
+      "Rotation": 331.5,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "7676ad3f-03fb-4038-8496-aa2de51085ba",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -178.03,
+        "y": 1.218,
+        "z": 107.92
+      },
+      "Rotation": 94.72969,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "783ff352-0728-4169-8f1e-42c2695ae52c",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 158.33,
+        "y": 3.624,
+        "z": 428.53
+      },
+      "Rotation": 169.729568,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "7869473c-17c2-4db8-ab57-c5a0546d5a69",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -155.781,
+        "y": 9.671,
+        "z": -26.933
+      },
+      "Rotation": 2.51923227,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "789e2418-ed73-40b7-be6c-e3ed899e1a40",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 244.86,
+        "y": -3.21,
+        "z": -40.06
+      },
+      "Rotation": 259.729858,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "78c2dfb1-ba00-4ddf-a523-67752074b369",
+      "Infiltration": "",
+      "Position": {
+        "x": 222.497009,
+        "y": 0.5250015,
+        "z": 182.676
+      },
+      "Rotation": 101.827583,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "7914fc21-265d-417b-9ce3-386f69d2762b",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 175.09,
+        "y": 1.029,
+        "z": 173.602
+      },
+      "Rotation": 281.824554,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "796cca85-8415-45d3-833c-c3fa8ca9bddb",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -52.407,
+        "y": 0.668,
+        "z": -66.38
+      },
+      "Rotation": 107.519135,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 34
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "79a51362-4e5f-47ba-afaf-290b94f9cf9e",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -206.343,
+        "y": 3.367,
+        "z": 180.998
+      },
+      "Rotation": 4.729717,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 6,
+      "DelayToCanSpawnSec": 40,
+      "Id": "79c5e1b8-f701-433b-9639-d1a51a4e423f",
+      "Infiltration": "",
+      "Position": {
+        "x": -35.53,
+        "y": 1.464,
+        "z": 156.55
+      },
+      "Rotation": 50.4,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW01",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "79fc6be4-2b69-4ca8-a08f-a6cce168d790",
+      "Infiltration": "",
+      "Position": {
+        "x": 114.210007,
+        "y": 1.25,
+        "z": 192.06
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneColumn",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 14,
+      "DelayToCanSpawnSec": 40,
+      "Id": "7a32e730-35d1-45b6-b4f0-259fcea83073",
+      "Infiltration": "",
+      "Position": {
+        "x": 39.037,
+        "y": 2.848,
+        "z": 203.36
+      },
+      "Rotation": 359.110931,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 3,
+      "DelayToCanSpawnSec": 40,
+      "Id": "7db97a66-8690-4774-be36-beaac6fe92d7",
+      "Infiltration": "",
+      "Position": {
+        "x": 76.327,
+        "y": 2.838,
+        "z": 288.368
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "7f644e0e-ba02-4107-a625-f38c4c31f714",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 166.96,
+        "y": -1.451,
+        "z": -132.76
+      },
+      "Rotation": 268.9683,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordiaParking",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 9,
+      "DelayToCanSpawnSec": 40,
+      "Id": "7ffdbb29-cfd0-43ce-b404-1a0ed8520fad",
+      "Infiltration": "",
+      "Position": {
+        "x": 210.91,
+        "y": -1.22,
+        "z": 350.161
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "80802ed7-2887-4023-84b6-972b0c9b0b55",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -94.56,
+        "y": 1.414,
+        "z": 125.441
+      },
+      "Rotation": 184.72963,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 3,
+      "DelayToCanSpawnSec": 40,
+      "Id": "80ad39b4-0045-445e-b4b7-3a138018111f",
+      "Infiltration": "",
+      "Position": {
+        "x": 81.4,
+        "y": 2.757,
+        "z": 297.38
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 7,
+      "DelayToCanSpawnSec": 40,
+      "Id": "81e0fc0e-64c0-4ae1-a248-a924524ac726",
+      "Infiltration": "",
+      "Position": {
+        "x": -133.321,
+        "y": 0.6079955,
+        "z": -26.729
+      },
+      "Rotation": 8.731616,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordiaParking",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 9,
+      "DelayToCanSpawnSec": 40,
+      "Id": "831ca29f-2e0b-4e00-825a-6974afa58ecb",
+      "Infiltration": "",
+      "Position": {
+        "x": 258.023,
+        "y": -1.227,
+        "z": 357.136
+      },
+      "Rotation": 180,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "8336d9db-1e63-4df7-a6d2-7b9efc7d5b65",
+      "Infiltration": "",
+      "Position": {
+        "x": 164.280014,
+        "y": 0.544002533,
+        "z": 136.68
+      },
+      "Rotation": 73.40837,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "8464e389-d91c-45d4-9e99-5b61d5bcdc69",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": -4.34199524,
+        "y": 1.65800035,
+        "z": 151.643982
+      },
+      "Rotation": 3.67021,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "84983058-e647-4955-a40a-1efe6c6b959b",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 245.03,
+        "y": -3.21,
+        "z": -38.56
+      },
+      "Rotation": 259.729858,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCard1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 7,
+      "DelayToCanSpawnSec": 40,
+      "Id": "85f5aef1-6c91-4e11-8148-3e9da50790fe",
+      "Infiltration": "",
+      "Position": {
+        "x": 57.3770142,
+        "y": 0.270000458,
+        "z": -55.4929962
+      },
+      "Rotation": 309.888733,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordiaParking",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 9,
+      "DelayToCanSpawnSec": 40,
+      "Id": "87ec4ca4-3d19-46a0-bd3e-92ce012210c5",
+      "Infiltration": "",
+      "Position": {
+        "x": 203.155,
+        "y": -1.227,
+        "z": 405.033
+      },
+      "Rotation": 99.85764,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "882227cc-5a26-41d8-9cb9-a0d8d10b8444",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -227.27,
+        "y": 5.226,
+        "z": 282.533
+      },
+      "Rotation": 25.0000076,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneColumn",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 14,
+      "DelayToCanSpawnSec": 40,
+      "Id": "8946ce33-504a-4a8d-922d-29853fa622f7",
+      "Infiltration": "",
+      "Position": {
+        "x": 38.39,
+        "y": 2.159,
+        "z": 194.976
+      },
+      "Rotation": 301.882233,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "89851e78-0a67-4001-9d43-533f1ea13a71",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 37.439,
+        "y": 1.197,
+        "z": 66.398
+      },
+      "Rotation": 287.434448,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "89d6c4f6-9c38-4163-b3ac-ac926bf47b6f",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -165.629,
+        "y": 3.158,
+        "z": 183.074
+      },
+      "Rotation": 74.27901,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "8a91f7ea-9669-4fdc-b677-57a868b18268",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -95.617,
+        "y": 1.414,
+        "z": 127.088
+      },
+      "Rotation": 184.72963,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "8b0b1cf1-f045-4a53-bf61-6f14adc71f75",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -151.106,
+        "y": 0.736,
+        "z": -66.902
+      },
+      "Rotation": 15.3466482,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "8b2329e2-3502-4c63-b744-6f3065ff3530",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -58.333,
+        "y": 3.214,
+        "z": -145.348
+      },
+      "Rotation": 2.51925588,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "8b301a0d-e694-4f24-b938-32329a5084f5",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 11.1879883,
+        "y": 1.78800011,
+        "z": 159.064
+      },
+      "Rotation": 335.685852,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 3,
+      "DelayToCanSpawnSec": 40,
+      "Id": "8be3e4e4-b892-4feb-9170-9460e1296870",
+      "Infiltration": "",
+      "Position": {
+        "x": 95.922,
+        "y": 2.684,
+        "z": 306.475
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "8c82c86e-22d6-4a98-baf5-507b366b3dd9",
+      "Infiltration": "",
+      "Position": {
+        "x": 226.77002,
+        "y": 0.458999634,
+        "z": 218.89
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCard1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 6,
+      "DelayToCanSpawnSec": 40,
+      "Id": "8cf15e13-e28e-4dd5-9d80-2e8e467bb900",
+      "Infiltration": "",
+      "Position": {
+        "x": 38.52002,
+        "y": 0.11000061,
+        "z": -46.7979965
+      },
+      "Rotation": 309.888733,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCard1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 6,
+      "DelayToCanSpawnSec": 40,
+      "Id": "8d72831e-5ab0-4637-9430-9fc5721aee96",
+      "Infiltration": "",
+      "Position": {
+        "x": 44.8300171,
+        "y": 0.270000458,
+        "z": -36.85
+      },
+      "Rotation": 309.888733,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "8e8fd66a-db92-49fd-9c82-2cd7a7ff1d5e",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -136.26,
+        "y": 2.34,
+        "z": 402.74
+      },
+      "Rotation": 271.2534,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "8eb7065a-df86-48c9-ace7-bc6e59372ad3",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 226.515,
+        "y": 0.642,
+        "z": 170.513
+      },
+      "Rotation": 263.604279,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "8ee254ee-954f-4f9f-b04d-23abb8cecf7e",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": -31.017,
+        "y": 2.615,
+        "z": 466.544
+      },
+      "Rotation": 181.253433,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "8f1d72e8-8dee-4a6b-b86c-412a0cca080c",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 234.399,
+        "y": -2.049,
+        "z": -105.547
+      },
+      "Rotation": 4.72974443,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "8f778e29-76f7-4f73-bcd9-d93e92e58d65",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -35.453,
+        "y": 1.429,
+        "z": 80.308
+      },
+      "Rotation": 94.72958,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "8f82ccc0-378c-4007-b281-cbd7cdc75f43",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 170.08,
+        "y": 0.988,
+        "z": 169.61
+      },
+      "Rotation": 281.824554,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "8faf7e0f-ba4a-4b7b-9ed7-642d84db17d2",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -43.209,
+        "y": 6.7,
+        "z": -114.198
+      },
+      "Rotation": 272.519379,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSnipeStilo",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 90
+        }
+      },
+      "CorePointId": 18,
+      "DelayToCanSpawnSec": 40,
+      "Id": "902865e5-67b4-4d09-9db5-b0bf4508e787",
+      "Infiltration": "",
+      "Position": {
+        "x": -161.81,
+        "y": 14.9,
+        "z": -4.299999
+      },
+      "Rotation": 11.7017088,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "906b382a-b467-40d6-8ae6-947b42e0712c",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 174.52,
+        "y": 1.29,
+        "z": 176.78
+      },
+      "Rotation": 281.824554,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "906d71d5-db71-47c1-8a58-0f48f58daea1",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": -32.585,
+        "y": 2.615,
+        "z": 466.542
+      },
+      "Rotation": 181.253433,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "91635471-4f27-4156-9801-9dbdf80f2970",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -226.153,
+        "y": 5.226,
+        "z": 280.783
+      },
+      "Rotation": 25.0000076,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCinema",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 4,
+      "DelayToCanSpawnSec": 40,
+      "Id": "9220b7ce-e705-4ba9-be1f-7fb7a9d1d72a",
+      "Infiltration": "",
+      "Position": {
+        "x": -52.284,
+        "y": -0.179458022,
+        "z": 386.267
+      },
+      "Rotation": 92.4,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "93427305-4f03-44d6-8690-7c24dbbb4128",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": -4.271988,
+        "y": 1.65800035,
+        "z": 153.023987
+      },
+      "Rotation": 3.67021,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "934cdbef-b43f-4690-aa4a-b34dc193abd0",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 99.03,
+        "y": -1.854,
+        "z": -158.78
+      },
+      "Rotation": 2.51932168,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 2,
+      "DelayToCanSpawnSec": 40,
+      "Id": "9425eb3e-1eee-4d93-9d2f-b3c92e86799d",
+      "Infiltration": "",
+      "Position": {
+        "x": 144.582,
+        "y": 3.531,
+        "z": 357.876
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "95453f5c-5ca5-405f-8872-ea088ca155c3",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": -32.607,
+        "y": 2.615,
+        "z": 465.087
+      },
+      "Rotation": 181.253433,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "97185451-3b24-4e74-baa1-6a706f09c520",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 4.9119873,
+        "y": 1.77900016,
+        "z": 160.613983
+      },
+      "Rotation": 57.23363,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "97513a7b-d467-454a-8232-2e77f3e386ef",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 9.087997,
+        "y": 2.568,
+        "z": 452.543976
+      },
+      "Rotation": 177.4608,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "999c413b-05eb-4c30-a4ef-4e0c95c838ef",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 18.5980072,
+        "y": 2.36800027,
+        "z": 456.764
+      },
+      "Rotation": 177.4608,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "9a479113-f5ac-433e-aa4b-b6f6c6b8d5e4",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -106.95,
+        "y": 0.662,
+        "z": -30.759
+      },
+      "Rotation": 107.519135,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 3,
+      "DelayToCanSpawnSec": 40,
+      "Id": "9b03fc7f-8438-43a2-87bd-5f2c606962de",
+      "Infiltration": "",
+      "Position": {
+        "x": 101.469,
+        "y": 2.676,
+        "z": 290.25
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 7,
+      "DelayToCanSpawnSec": 40,
+      "Id": "9b2a6106-750a-4429-9243-a3a325916eba",
+      "Infiltration": "",
+      "Position": {
+        "x": -155.71,
+        "y": 0.74,
+        "z": -22.7799988
+      },
+      "Rotation": 8.731616,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "9b4cc2e1-662c-4f96-af4f-f022527d9868",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 167.909988,
+        "y": -1.451,
+        "z": -128.53
+      },
+      "Rotation": 268.9683,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 43
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "9c57887e-d1c9-4e0f-94e6-558d49b96faf",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 229.38,
+        "y": 3.37,
+        "z": 410.74
+      },
+      "Rotation": 169.7296,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "9dd4bcc0-062e-45a4-9346-2b488ed4ad72",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 10.3280029,
+        "y": 1.78800011,
+        "z": 156.053986
+      },
+      "Rotation": 335.685852,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCard1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 7,
+      "DelayToCanSpawnSec": 40,
+      "Id": "9e0a64a1-a5ef-4429-b185-0854d5b2cb81",
+      "Infiltration": "",
+      "Position": {
+        "x": 70.99402,
+        "y": 0.270000458,
+        "z": -49.2839966
+      },
+      "Rotation": 84.2096558,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "9e3be350-92e3-434b-befc-b12ccbb2af45",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -244.442,
+        "y": 2.193,
+        "z": 237.972
+      },
+      "Rotation": 205,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSnipeCinema",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 90
+        }
+      },
+      "CorePointId": 10,
+      "DelayToCanSpawnSec": 40,
+      "Id": "9ec982c2-e462-4cbc-9e12-c31b7c1440ed",
+      "Infiltration": "",
+      "Position": {
+        "x": -166.03,
+        "y": 23.1993332,
+        "z": 410.85
+      },
+      "Rotation": 90,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordiaParking",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 9,
+      "DelayToCanSpawnSec": 40,
+      "Id": "9ee33ac3-002a-471e-891a-9c5524abebca",
+      "Infiltration": "",
+      "Position": {
+        "x": 271.591,
+        "y": -1.227,
+        "z": 379.893
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneColumn",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "9f584624-1f11-4ff0-a560-e0ff20b000a9",
+      "Infiltration": "",
+      "Position": {
+        "x": -16.387,
+        "y": 2.633,
+        "z": 231.312
+      },
+      "Rotation": 114.231476,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "9f6cbe96-7d68-45bf-8f4b-4ccac2550961",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 14.9980011,
+        "y": 2.568,
+        "z": 453.814
+      },
+      "Rotation": 177.4608,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 15,
+      "DelayToCanSpawnSec": 40,
+      "Id": "9f8559ea-a4a5-4819-b3f8-bcd3e1fd39e1",
+      "Infiltration": "",
+      "Position": {
+        "x": -47.515,
+        "y": 0.612,
+        "z": -67.681
+      },
+      "Rotation": 8.731616,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSnipeBuilding",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 12,
+      "DelayToCanSpawnSec": 40,
+      "Id": "a02c0364-6202-4d62-bb23-2bc424b84484",
+      "Infiltration": "",
+      "Position": {
+        "x": -24.67,
+        "y": 21.1835,
+        "z": 228.13
+      },
+      "Rotation": 90,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCinema",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 4,
+      "DelayToCanSpawnSec": 40,
+      "Id": "a045efd7-74d2-4c5c-896d-e8a2aceaf712",
+      "Infiltration": "",
+      "Position": {
+        "x": -134.383,
+        "y": 2.545,
+        "z": 395.888
+      },
+      "Rotation": 180,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSnipeCinema",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 90
+        }
+      },
+      "CorePointId": 10,
+      "DelayToCanSpawnSec": 40,
+      "Id": "a05cdcc7-7701-4774-994b-bfd642562552",
+      "Infiltration": "",
+      "Position": {
+        "x": -166.71,
+        "y": 23.1993332,
+        "z": 390.43
+      },
+      "Rotation": 90,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "a0bca4c5-ae22-462c-9aa1-290ba3023b84",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -230.641,
+        "y": 2.196,
+        "z": 342.45
+      },
+      "Rotation": 340.000031,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "a0f1b844-cb41-483c-8203-a7a2b0413f5e",
+      "Infiltration": "",
+      "Position": {
+        "x": 256.983,
+        "y": -5.336998,
+        "z": 77.123
+      },
+      "Rotation": 278.614166,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordiaParking",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 9,
+      "DelayToCanSpawnSec": 40,
+      "Id": "a1750f93-a601-42f1-a4e2-9f10a9f97dda",
+      "Infiltration": "",
+      "Position": {
+        "x": 257.73,
+        "y": -1.227,
+        "z": 359.39
+      },
+      "Rotation": 180,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 15,
+      "DelayToCanSpawnSec": 40,
+      "Id": "a1a5494b-6a9f-49d4-bd5b-ee3b90265994",
+      "Infiltration": "",
+      "Position": {
+        "x": -50.032,
+        "y": 5.22,
+        "z": -62.1
+      },
+      "Rotation": 8.731616,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "a272ace4-7ae2-4cd1-a301-bcbad66c1ffa",
+      "Infiltration": "",
+      "Position": {
+        "x": 195.240021,
+        "y": 1.24000168,
+        "z": 221.27
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneFactory",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 5,
+      "DelayToCanSpawnSec": 40,
+      "Id": "a2a8d359-8b0d-43c4-9123-a4166fbae408",
+      "Infiltration": "",
+      "Position": {
+        "x": -170.34,
+        "y": 2.26,
+        "z": 287.44
+      },
+      "Rotation": 130.584167,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 42
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "a2afda58-3556-4186-aad7-72c7f34a1334",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 211.085,
+        "y": 3.935,
+        "z": 297.4
+      },
+      "Rotation": 334.7296,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSnipeCard",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 90
+        }
+      },
+      "CorePointId": 16,
+      "DelayToCanSpawnSec": 40,
+      "Id": "a2ce1075-9d47-4503-bb08-f68be3ca3824",
+      "Infiltration": "",
+      "Position": {
+        "x": 43.74,
+        "y": 28.512,
+        "z": -17.0099983
+      },
+      "Rotation": 11.7017088,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConstruction",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 2,
+      "DelayToCanSpawnSec": 40,
+      "Id": "a2ff9df6-ce0b-48c8-ac41-665e723d89c7",
+      "Infiltration": "",
+      "Position": {
+        "x": 209.379,
+        "y": 4.051,
+        "z": 298.748
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "a3ab1bc5-47c5-4b00-a364-770d046ce559",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -108.95,
+        "y": 0.662,
+        "z": -28.307
+      },
+      "Rotation": 107.519135,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "a3cb743f-d96a-4927-a91c-8c1d9e3c4d0c",
+      "Infiltration": "",
+      "Position": {
+        "x": 164.554016,
+        "y": 0.544002533,
+        "z": 138.12
+      },
+      "Rotation": 73.40837,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordiaParking",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 9,
+      "DelayToCanSpawnSec": 40,
+      "Id": "a44c4bc9-adf6-4457-89fc-df8c31cd42df",
+      "Infiltration": "",
+      "Position": {
+        "x": 212.68,
+        "y": -1.22,
+        "z": 350.13
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneFactory",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 5,
+      "DelayToCanSpawnSec": 40,
+      "Id": "a55a79be-ab3e-4af1-a243-667d81abda9a",
+      "Infiltration": "",
+      "Position": {
+        "x": -101.15,
+        "y": 2.32,
+        "z": 269.47
+      },
+      "Rotation": 353.8347,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordia_1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 8,
+      "DelayToCanSpawnSec": 40,
+      "Id": "a5de40ba-927a-416c-85dc-2505bfdd50a5",
+      "Infiltration": "",
+      "Position": {
+        "x": 271.827,
+        "y": 3.526,
+        "z": 369.477
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "a5f20625-9d4a-4549-8a52-453199357ace",
+      "Infiltration": "",
+      "Position": {
+        "x": 173.77002,
+        "y": -1.21999741,
+        "z": 56.25
+      },
+      "Rotation": 278.614166,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "a6ac7812-b011-4b25-9b74-9743e79ad4ee",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -111.445,
+        "y": 0.668,
+        "z": -30.917
+      },
+      "Rotation": 107.519135,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "a6b0f695-68d1-480c-8f64-996725d71036",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 168.3,
+        "y": -1.451,
+        "z": -130.72
+      },
+      "Rotation": 270.487122,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_2",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 7,
+      "DelayToCanSpawnSec": 40,
+      "Id": "a7a40014-1777-402c-ae1e-c3432d6e8cf8",
+      "Infiltration": "",
+      "Position": {
+        "x": -96.61,
+        "y": 0.9370003,
+        "z": 83.2299957
+      },
+      "Rotation": 162.1,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "a7d7d9c1-8877-400c-b71b-1c2742dfe572",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 58.949,
+        "y": 0.553,
+        "z": 43.507
+      },
+      "Rotation": 22.0116329,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "a9bd8162-167c-40e5-9027-20a2fe5b6ef9",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -195.641,
+        "y": 4.992,
+        "z": 387.005
+      },
+      "Rotation": 190.496658,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "a9dffad6-bc0d-48ae-a314-acd62b128fd8",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 45.106,
+        "y": 2.717,
+        "z": 413.596
+      },
+      "Rotation": 241.253387,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "aa9222f5-c4ee-4569-8e5e-7689d4bad545",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 93.93,
+        "y": 2.579,
+        "z": 451.26
+      },
+      "Rotation": 169.729568,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 15,
+      "DelayToCanSpawnSec": 40,
+      "Id": "aaf198dd-5125-4fb0-b510-fc53ef30796c",
+      "Infiltration": "",
+      "Position": {
+        "x": -46.111,
+        "y": 0.616,
+        "z": -67.664
+      },
+      "Rotation": 8.731616,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCinema",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 4,
+      "DelayToCanSpawnSec": 40,
+      "Id": "ab1504a9-30f0-43d9-ad2a-a3cf1dfe97f2",
+      "Infiltration": "",
+      "Position": {
+        "x": -191.95,
+        "y": 8.76,
+        "z": 423.31
+      },
+      "Rotation": 90,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "ab3739bb-31fd-4868-af70-36955a9ae6d1",
+      "Infiltration": "",
+      "Position": {
+        "x": 184.840012,
+        "y": -4.199997,
+        "z": 30.2
+      },
+      "Rotation": 278.614166,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 19,
+      "DelayToCanSpawnSec": 40,
+      "Id": "aba9c9a6-2038-4a7f-a2f1-5ae206b9aceb",
+      "Infiltration": "",
+      "Position": {
+        "x": 243.63,
+        "y": -5.369999,
+        "z": 29.31
+      },
+      "Rotation": 278.614166,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "abc70143-bb75-4244-a87a-9df9e0fcdd33",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 170.096,
+        "y": 0.988,
+        "z": 168.261
+      },
+      "Rotation": 281.824554,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "ac155f80-d9a7-431b-8608-0e6e74287afd",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 273.3,
+        "y": -1.16,
+        "z": 377.25
+      },
+      "Rotation": 334.7296,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "ac6cccdf-66ef-4d4a-801f-5c95d67a05fe",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 123.313,
+        "y": 0.503,
+        "z": 125.374
+      },
+      "Rotation": 139.014771,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "ac7b2cb8-829c-4140-90f3-063b03687764",
+      "Infiltration": "",
+      "Position": {
+        "x": 165.540009,
+        "y": -1.27999878,
+        "z": 106.77
+      },
+      "Rotation": 278.614166,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "ad71c83a-8552-468e-9bbb-7530d53b1cb0",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 104.25,
+        "y": -1.854,
+        "z": -162.48
+      },
+      "Rotation": 2.51932168,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "adce64c7-8895-4530-bbd2-16644a35224a",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 185.35,
+        "y": 3.529,
+        "z": 451.26
+      },
+      "Rotation": 134.938431,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "ade8885f-b41b-4e5f-a31d-4a5ff0aef1e7",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -162.386,
+        "y": 3.158,
+        "z": 182.139
+      },
+      "Rotation": 74.27901,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordia_1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 8,
+      "DelayToCanSpawnSec": 40,
+      "Id": "ae097261-c5aa-4226-8ead-5cc8264f24b3",
+      "Infiltration": "",
+      "Position": {
+        "x": 202.85,
+        "y": 3.545,
+        "z": 402.46
+      },
+      "Rotation": 90,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "aea27585-1f8c-49dc-9524-88fe4e9f0bdd",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 46.174,
+        "y": 2.717,
+        "z": 415.754
+      },
+      "Rotation": 241.253387,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "aeab5681-09ec-47fb-87d5-571b6e33522f",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -181.525,
+        "y": 2.451,
+        "z": 415.068
+      },
+      "Rotation": 11.8153534,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "aeb13e1b-ba7b-4f2c-92a8-3d7120b32dbe",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -50.789,
+        "y": 0.668,
+        "z": -65.073
+      },
+      "Rotation": 107.519135,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 15,
+      "DelayToCanSpawnSec": 40,
+      "Id": "aeffc6c4-ac5e-4e38-a7f4-cc16f99a3a97",
+      "Infiltration": "",
+      "Position": {
+        "x": -31.45,
+        "y": 0.6080003,
+        "z": -70.643
+      },
+      "Rotation": 8.731616,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "af2c001e-a978-4c68-9acc-eac8709cdc7c",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 177.514,
+        "y": 3.093,
+        "z": 236.545
+      },
+      "Rotation": 356.824432,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW01",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "afcd17eb-19b4-4b95-adf8-95f9041c01c3",
+      "Infiltration": "",
+      "Position": {
+        "x": 75.3500061,
+        "y": -0.6969986,
+        "z": 90.2299957
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "b0126d65-ba76-45ad-b25e-32f4f3509904",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 7.85800171,
+        "y": 1.81900012,
+        "z": 161.583984
+      },
+      "Rotation": 335.685852,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "b049c6f8-afb9-42f9-9591-2f265fef2097",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 5.34100342,
+        "y": 1.77900016,
+        "z": 156.336975
+      },
+      "Rotation": 57.23363,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "b14d74dc-3024-493a-bc59-2f3fc244a185",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 275.666,
+        "y": -4.431,
+        "z": 88.001
+      },
+      "Rotation": 93.71277,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordiaParking",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 9,
+      "DelayToCanSpawnSec": 40,
+      "Id": "b2ac5616-518f-4d93-90a1-f5f4248c5196",
+      "Infiltration": "",
+      "Position": {
+        "x": 273.069,
+        "y": -1.227,
+        "z": 375.708
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "b33881ed-42df-4332-801d-6623e86c11e5",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 39.561,
+        "y": 1.197,
+        "z": 66.17
+      },
+      "Rotation": 287.434448,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "b375b2e4-d13f-4e81-9b58-672da90131f0",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -152.382,
+        "y": 0.663,
+        "z": -62.95
+      },
+      "Rotation": 15.3466482,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 15,
+      "DelayToCanSpawnSec": 40,
+      "Id": "b3cf4743-0769-4758-9686-e8bdae22a6a7",
+      "Infiltration": "",
+      "Position": {
+        "x": -50.974,
+        "y": 5.152,
+        "z": -29.5530014
+      },
+      "Rotation": 8.731616,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordiaParking",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 9,
+      "DelayToCanSpawnSec": 40,
+      "Id": "b3f45457-47ef-4115-b0d8-23509ba5635d",
+      "Infiltration": "",
+      "Position": {
+        "x": 256.02,
+        "y": -1.227,
+        "z": 357.65
+      },
+      "Rotation": 180,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConstruction",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 2,
+      "DelayToCanSpawnSec": 40,
+      "Id": "b5e4513a-e60d-49b8-ba5a-a5c98bad38ad",
+      "Infiltration": "",
+      "Position": {
+        "x": 214.818,
+        "y": 3.37095356,
+        "z": 329.919
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "b865e8aa-2843-43ec-a839-f8515aeafbcc",
+      "Infiltration": "",
+      "Position": {
+        "x": 187.990021,
+        "y": 1.78000259,
+        "z": 191.28
+      },
+      "Rotation": 101.827583,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "b96df3dc-23f2-4e1d-8a9a-9fbe05a94f47",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 8.007996,
+        "y": 1.80700016,
+        "z": 157.963959
+      },
+      "Rotation": 335.685852,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 42
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "bb776772-5164-40f4-984b-67ce81dc2e4b",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 206.924,
+        "y": 3.935,
+        "z": 295.835
+      },
+      "Rotation": 334.7296,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCinema",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 4,
+      "DelayToCanSpawnSec": 40,
+      "Id": "bcab247a-1a96-4463-850f-ece57e4d461a",
+      "Infiltration": "",
+      "Position": {
+        "x": -141.018,
+        "y": 2.545,
+        "z": 400.981
+      },
+      "Rotation": 180,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "bdf5a017-bab7-4abe-be10-4a1879de7662",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -175.044,
+        "y": 2.455,
+        "z": 466.141
+      },
+      "Rotation": 181.253433,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneFactory",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 5,
+      "DelayToCanSpawnSec": 40,
+      "Id": "be3b6e0e-692b-4fe3-b8da-8b9969fce203",
+      "Infiltration": "",
+      "Position": {
+        "x": -103.881,
+        "y": 2.32,
+        "z": 267.981018
+      },
+      "Rotation": 90,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "bf021e1e-e128-4fae-b088-d4929588a696",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 41.755,
+        "y": 1.197,
+        "z": 64.192
+      },
+      "Rotation": 4.72967052,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "c0247ccc-9087-47fc-8260-2d23ac5bbb5b",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 259.911,
+        "y": -5.94,
+        "z": 52.289
+      },
+      "Rotation": 319.729767,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 19,
+      "DelayToCanSpawnSec": 40,
+      "Id": "c08054ed-526e-4b9c-9472-f3508a287782",
+      "Infiltration": "",
+      "Position": {
+        "x": 214.87001,
+        "y": -4.46999741,
+        "z": 30.41
+      },
+      "Rotation": 278.614166,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_2",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 7,
+      "DelayToCanSpawnSec": 40,
+      "Id": "c096aa63-97d1-424a-b095-b949b95d21fd",
+      "Infiltration": "",
+      "Position": {
+        "x": -77.38,
+        "y": 0.9370003,
+        "z": 75.04
+      },
+      "Rotation": 162.1,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordia_1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 8,
+      "DelayToCanSpawnSec": 40,
+      "Id": "c15e5471-af4b-4ed3-b186-861bebe5040c",
+      "Infiltration": "",
+      "Position": {
+        "x": 207.76,
+        "y": 3.545,
+        "z": 404.55
+      },
+      "Rotation": 90,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "c1e6eaa9-74de-4da9-ac49-62faf320c4ab",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 185.446,
+        "y": 3.529,
+        "z": 456.849
+      },
+      "Rotation": 134.938431,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "c2477145-0481-4d79-a1cb-5e13f6454478",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -176.05,
+        "y": 1.218,
+        "z": 108.38
+      },
+      "Rotation": 94.72969,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "c2a3cb3b-a64f-485b-bf2b-c14fc5ec3938",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 50.602,
+        "y": 4.465,
+        "z": -134.514
+      },
+      "Rotation": 273.305542,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSnipeCarShowroom",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 90
+        }
+      },
+      "CorePointId": 11,
+      "DelayToCanSpawnSec": 40,
+      "Id": "c2de3400-bd4e-492b-bd38-8defda3da573",
+      "Infiltration": "",
+      "Position": {
+        "x": 58.61,
+        "y": 11.9036674,
+        "z": 309.91
+      },
+      "Rotation": 90,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "c36b37b1-e654-45b8-a921-4864d1a325a4",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 3.79800415,
+        "y": 1.77900016,
+        "z": 153.68399
+      },
+      "Rotation": 57.23363,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 3,
+      "DelayToCanSpawnSec": 40,
+      "Id": "c4351b8f-1cfe-4ab0-9ebd-b7439509ef51",
+      "Infiltration": "",
+      "Position": {
+        "x": 85.81,
+        "y": 5.4,
+        "z": 348.52
+      },
+      "Rotation": 150.2019,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "c57d7757-17e5-4ffd-af06-3ed4098bd462",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -97.252,
+        "y": 1.414,
+        "z": 128.329
+      },
+      "Rotation": 184.72963,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW01",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "c5afeb5c-808d-44e8-94d7-ec0a825379a7",
+      "Infiltration": "",
+      "Position": {
+        "x": 81.32602,
+        "y": 0.8840027,
+        "z": 163.591
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "c5cd706c-d695-4d8d-9592-9f5c552fd444",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 54.977,
+        "y": 0.553,
+        "z": 44.36
+      },
+      "Rotation": 109.729546,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "c603cdaf-2ad3-4270-929a-caedde8ac074",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 106.36,
+        "y": -2.04,
+        "z": 60.45
+      },
+      "Rotation": 63.4586678,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 6,
+      "DelayToCanSpawnSec": 40,
+      "Id": "c65d22d1-f066-45ea-8d6b-2fd897620224",
+      "Infiltration": "",
+      "Position": {
+        "x": -71.95,
+        "y": 1.464,
+        "z": 154.769989
+      },
+      "Rotation": 331.5,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "c736ae69-2631-4d51-b5ac-6a466c7c8dd8",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 185.557,
+        "y": 1.574,
+        "z": 188.963
+      },
+      "Rotation": 24.4516544,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "c754fbb3-f538-4f10-8bc5-107214df5951",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -116.636,
+        "y": 0.884,
+        "z": 57.38
+      },
+      "Rotation": 1.138527,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 34
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "c8a3c9e4-7998-41fa-b311-9e9feb35588c",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -204.056,
+        "y": 3.367,
+        "z": 179.404
+      },
+      "Rotation": 4.729717,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "c8b04f3f-1f80-49a7-8530-3180b3ff71e9",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 8.957977,
+        "y": 1.78800011,
+        "z": 157.02298
+      },
+      "Rotation": 335.685852,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_2",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 7,
+      "DelayToCanSpawnSec": 40,
+      "Id": "c97900f2-27dd-4634-83b1-a4b29d62ece1",
+      "Infiltration": "",
+      "Position": {
+        "x": -93.88,
+        "y": 0.9370003,
+        "z": 86.85
+      },
+      "Rotation": 162.1,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "c9d0e6f0-8018-4ef0-a3d8-0daad105605f",
+      "Infiltration": "",
+      "Position": {
+        "x": 173.44,
+        "y": -1.21999741,
+        "z": 57.7399979
+      },
+      "Rotation": 278.614166,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 7,
+      "DelayToCanSpawnSec": 40,
+      "Id": "cc8b5b34-359e-4558-b1d2-bbc40c80c5d3",
+      "Infiltration": "",
+      "Position": {
+        "x": -158.92,
+        "y": 0.74,
+        "z": -27.77
+      },
+      "Rotation": 8.731616,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "cdabcf05-fa38-4640-89a6-294133b99a5c",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": -2.40397644,
+        "y": 1.65800035,
+        "z": 149.22
+      },
+      "Rotation": 3.67021,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 3,
+      "DelayToCanSpawnSec": 40,
+      "Id": "ce00a6ab-02d1-416f-a7b4-b2451a60133d",
+      "Infiltration": "",
+      "Position": {
+        "x": 78.042,
+        "y": 2.837,
+        "z": 286.172
+      },
+      "Rotation": 86.38937,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordiaParking",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 9,
+      "DelayToCanSpawnSec": 40,
+      "Id": "ce168050-e078-4ee4-bf85-d707d8b307dc",
+      "Infiltration": "",
+      "Position": {
+        "x": 271.213,
+        "y": -1.227,
+        "z": 378.527
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConstruction",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 2,
+      "DelayToCanSpawnSec": 40,
+      "Id": "ceb8a2ad-8fab-4cc7-9e90-ac982bfded28",
+      "Infiltration": "",
+      "Position": {
+        "x": 184.84,
+        "y": 3.41262436,
+        "z": 328.16
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "cec675dc-0443-44f1-90bb-61b0fc25b2fc",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": -2.63198853,
+        "y": 1.65800035,
+        "z": 154.414
+      },
+      "Rotation": 3.67021,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "cf94127f-36e9-4222-80fe-21168a27bee1",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 244.576,
+        "y": -3.21,
+        "z": -41.784
+      },
+      "Rotation": 259.729858,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "cfa21779-49ad-49b5-ae7a-33bc0bd0f620",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 98.71,
+        "y": 2.76,
+        "z": 450.63
+      },
+      "Rotation": 169.729568,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "cfdbef81-7026-4035-af30-b22d33815b18",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -153.903,
+        "y": 0.654,
+        "z": -64.471
+      },
+      "Rotation": 15.3466482,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConstruction",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 2,
+      "DelayToCanSpawnSec": 40,
+      "Id": "cfe9eb9a-5cf7-40be-bc3b-ed5a3b5110ba",
+      "Infiltration": "",
+      "Position": {
+        "x": 215.231,
+        "y": 3.37095356,
+        "z": 330.802
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCinema",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 4,
+      "DelayToCanSpawnSec": 40,
+      "Id": "d0862b2e-71ac-4d83-ba4e-a0121c3a43d1",
+      "Infiltration": "",
+      "Position": {
+        "x": -189.93,
+        "y": 8.76,
+        "z": 421.67
+      },
+      "Rotation": 90,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConstruction",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 2,
+      "DelayToCanSpawnSec": 40,
+      "Id": "d0948d55-bf22-49f1-aaae-bd8f1878704f",
+      "Infiltration": "",
+      "Position": {
+        "x": 206.164,
+        "y": 6.932,
+        "z": 299.252
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "d0bcc73b-7a8c-49d4-b715-1841f401cd51",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -59.728,
+        "y": 4.488,
+        "z": -149.696
+      },
+      "Rotation": 2.51925588,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW01",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "d11f96df-4ae3-4f5e-bd74-5ed88e6e75cc",
+      "Infiltration": "",
+      "Position": {
+        "x": 77.91002,
+        "y": 0.700000763,
+        "z": 165.45
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "d15412cb-093a-434b-b20c-dee298f3cd85",
+      "Infiltration": "",
+      "Position": {
+        "x": 186.52002,
+        "y": -4.37999725,
+        "z": 30.82
+      },
+      "Rotation": 278.614166,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "d193cee0-4e4f-486a-a8cc-26834fd64b1a",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -176.548,
+        "y": 2.455,
+        "z": 468.992
+      },
+      "Rotation": 181.253433,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "d1b472b5-9f83-43b5-a71b-58f880662301",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 107.18,
+        "y": -2.04,
+        "z": 63.05
+      },
+      "Rotation": 63.4586678,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_2",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 7,
+      "DelayToCanSpawnSec": 40,
+      "Id": "d1fcc53a-8aa8-4a7d-a6ed-d8b20f6add15",
+      "Infiltration": "",
+      "Position": {
+        "x": -98.32,
+        "y": 0.9370003,
+        "z": 86.31
+      },
+      "Rotation": 162.1,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 2,
+      "DelayToCanSpawnSec": 40,
+      "Id": "d327fdf5-ec5b-421b-865d-978466160d2a",
+      "Infiltration": "",
+      "Position": {
+        "x": 142.932,
+        "y": 3.622,
+        "z": 357.98
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "d390bbef-04f5-401b-a47b-a0d7c0f6eb69",
+      "Infiltration": "",
+      "Position": {
+        "x": 164.554016,
+        "y": 0.544002533,
+        "z": 138.12
+      },
+      "Rotation": 73.40837,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCard1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 7,
+      "DelayToCanSpawnSec": 40,
+      "Id": "d3d62ac0-c30a-4849-bea3-c6d9b2625e27",
+      "Infiltration": "",
+      "Position": {
+        "x": 63.6960144,
+        "y": 0.270000458,
+        "z": -55.2399979
+      },
+      "Rotation": 84.2096558,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordia_1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 8,
+      "DelayToCanSpawnSec": 40,
+      "Id": "d3f5f084-f4c8-467d-8a5f-278224ca1f27",
+      "Infiltration": "",
+      "Position": {
+        "x": 271.007,
+        "y": 3.526,
+        "z": 371.175
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "d4125c7a-6690-405b-ad08-ab66c3aa6d85",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -42.942,
+        "y": 6.67,
+        "z": -115.674
+      },
+      "Rotation": 272.519379,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "d4a83c9c-a8af-41ad-b480-4566aaddb1c3",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -119.289,
+        "y": 0.884,
+        "z": 61.504
+      },
+      "Rotation": 357.465179,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 6,
+      "DelayToCanSpawnSec": 40,
+      "Id": "d4cc7f3d-0420-4d2b-8117-7313919b8c12",
+      "Infiltration": "",
+      "Position": {
+        "x": -86.032,
+        "y": 1.464,
+        "z": 178.024
+      },
+      "Rotation": 162.1,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "d4dcb5bb-9231-4404-b0ba-3544e0f5f240",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": -13.868,
+        "y": 2.763,
+        "z": -132.861
+      },
+      "Rotation": 92.51915,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "d5213c2e-dc84-4151-b649-09b5149225cc",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 171.72,
+        "y": 1.1,
+        "z": 174.42
+      },
+      "Rotation": 281.824554,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW01",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "d533df15-b17b-4adf-a269-d7581ccfeb1c",
+      "Infiltration": "",
+      "Position": {
+        "x": 79.89801,
+        "y": 0.8840027,
+        "z": 165.156
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "d534c315-c773-4996-9dad-8db533ff7fa8",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 104.64,
+        "y": -2.132,
+        "z": 61.52
+      },
+      "Rotation": 109.729546,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "d5a78c68-5c50-4673-bdc3-06ec670a4a97",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -33.699,
+        "y": 1.429,
+        "z": 80.613
+      },
+      "Rotation": 94.72958,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 2,
+      "DelayToCanSpawnSec": 40,
+      "Id": "d5fb525c-cda5-4266-83ee-3ae239c9e089",
+      "Infiltration": "",
+      "Position": {
+        "x": 142.39,
+        "y": 3.52,
+        "z": 361.571
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "d6d5413b-44fb-4ce5-a5a1-9846c6a944cd",
+      "Infiltration": "",
+      "Position": {
+        "x": 259.068024,
+        "y": -5.336998,
+        "z": 76.575
+      },
+      "Rotation": 278.614166,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "d7b6bcfb-eaeb-42e0-a63f-69cf5c2f9d33",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 53.22,
+        "y": 4.531,
+        "z": -132.52
+      },
+      "Rotation": 277.088135,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 19,
+      "DelayToCanSpawnSec": 40,
+      "Id": "d841ec7b-3aba-4aa9-ad39-66168de6634d",
+      "Infiltration": "",
+      "Position": {
+        "x": 216.150009,
+        "y": -4.46999741,
+        "z": 30.71
+      },
+      "Rotation": 278.614166,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "d86d8ead-2302-4817-858e-74fa428a244e",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 223.788,
+        "y": 0.642,
+        "z": 170.845
+      },
+      "Rotation": 263.604279,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "d87780be-c25b-44b0-8340-27714ea6d4d0",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -174.294,
+        "y": 1.218,
+        "z": 107.643
+      },
+      "Rotation": 94.72969,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneHotel_1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 6,
+      "DelayToCanSpawnSec": 40,
+      "Id": "d9399a2e-24e4-4048-8fd6-c3ab91635398",
+      "Infiltration": "",
+      "Position": {
+        "x": -84.273,
+        "y": 1.464,
+        "z": 177.886
+      },
+      "Rotation": 162.1,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "da0cccb8-0123-4e04-b765-f31434dc56a6",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -195.947,
+        "y": 4.993,
+        "z": 389.306
+      },
+      "Rotation": 190.496658,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "daaa4a02-1f51-460b-bdf8-29b3bd2c838b",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 2.25097656,
+        "y": 1.82900012,
+        "z": 158.871979
+      },
+      "Rotation": 57.23363,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "dae85c43-6039-4755-bfe0-c0a3de2a9f3b",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 272,
+        "y": -1.16,
+        "z": 374.65
+      },
+      "Rotation": 334.7296,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "db356917-3655-4cb0-8e01-47eb593510e0",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -149.896,
+        "y": 9.669,
+        "z": -27.344
+      },
+      "Rotation": 2.51923227,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 43
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "dbdc91e7-8a95-4cb6-abf0-9d5de4ee1da0",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 226.23,
+        "y": 3.351,
+        "z": 410.5
+      },
+      "Rotation": 169.7296,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "dc34ebdc-8d69-454c-a36f-d9e2ba1dcfe7",
+      "Infiltration": "",
+      "Position": {
+        "x": 171.993011,
+        "y": 0.544002533,
+        "z": 153.186
+      },
+      "Rotation": 73.40837,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "dd8b106c-8f50-4e33-bb3b-39388c0eab41",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 43.754,
+        "y": 2.717,
+        "z": 416.533
+      },
+      "Rotation": 241.253387,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "ddca1267-6caa-4986-bd13-0ed29a81e6d2",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 10.1600037,
+        "y": 1.78800011,
+        "z": 158.207977
+      },
+      "Rotation": 335.685852,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "de0cd670-1399-475e-afca-036ff914ad5c",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 276.072,
+        "y": -4.431,
+        "z": 89.212
+      },
+      "Rotation": 93.71277,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "de5293e8-6ff3-4384-a2d5-169a94d039b2",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 121.548,
+        "y": 0.503,
+        "z": 126.294
+      },
+      "Rotation": 279.4518,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 40
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "df295b85-971d-4e9e-8239-018033690b5b",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 274.105,
+        "y": -1.16,
+        "z": 376.208
+      },
+      "Rotation": 334.7296,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "df949703-1471-4367-a395-3afa78fcf886",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 0.79800415,
+        "y": 1.65800035,
+        "z": 155.874
+      },
+      "Rotation": 3.67021,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneColumn",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "e0e8f4c2-3439-4016-8501-be5d23b897c7",
+      "Infiltration": "",
+      "Position": {
+        "x": -12.53,
+        "y": 2.633,
+        "z": 231.915
+      },
+      "Rotation": 114.231476,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "e13b878f-b4ec-4ef3-aacd-47bca490e401",
+      "Infiltration": "",
+      "Position": {
+        "x": 234.572021,
+        "y": 0.458999634,
+        "z": 215.794
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "e3b84d57-bdd7-4e38-ac5f-62dad937e572",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -193.902,
+        "y": 4.993,
+        "z": 389.207
+      },
+      "Rotation": 190.496658,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "e401a964-689a-464e-8b66-c485933f9c0d",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 226.23,
+        "y": 3.351,
+        "z": 410.5
+      },
+      "Rotation": 169.7296,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "e5c87107-42a5-4019-a437-ef8f6d703122",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 273.202,
+        "y": 4.781,
+        "z": 516.697
+      },
+      "Rotation": 236.6915,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "e5da63fb-4d33-4ebb-a621-dd414deecab5",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 14.447998,
+        "y": 2.568,
+        "z": 455.404022
+      },
+      "Rotation": 177.4608,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 34
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "e5e1d18b-da5b-4d2d-a445-54bd9117eee7",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -203.697,
+        "y": 3.367,
+        "z": 182.271
+      },
+      "Rotation": 4.729717,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "e6509e2d-3b03-4079-8904-c499dc2efba4",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 274.738,
+        "y": 4.782,
+        "z": 517.334
+      },
+      "Rotation": 236.6915,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCinema",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 4,
+      "DelayToCanSpawnSec": 40,
+      "Id": "e73b9322-0119-4617-a29d-296118aa9dc9",
+      "Infiltration": "",
+      "Position": {
+        "x": -139.949,
+        "y": 2.545,
+        "z": 401.048
+      },
+      "Rotation": 180,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW01",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "e740631e-f0f4-4c02-9626-6e31e8ec4154",
+      "Infiltration": "",
+      "Position": {
+        "x": 60.7000122,
+        "y": 0.520000458,
+        "z": 169.49
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "e751b2f9-4919-40d1-8877-b9c4bcbf5435",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 275.417,
+        "y": 4.782,
+        "z": 516.126
+      },
+      "Rotation": 236.6915,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "e8b8754b-c2a7-4563-be0f-74bc4b34cdee",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 277.164,
+        "y": -4.431,
+        "z": 87.967
+      },
+      "Rotation": 93.71277,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneConcordia_1",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 8,
+      "DelayToCanSpawnSec": 40,
+      "Id": "e9ef467a-0098-4d88-98b5-055da40bdfbc",
+      "Infiltration": "",
+      "Position": {
+        "x": 201.178,
+        "y": 3.545,
+        "z": 401.783
+      },
+      "Rotation": 90,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "ea574eed-cdcd-4448-801b-a8398cc6b8df",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 154.142,
+        "y": 3.624,
+        "z": 428.129
+      },
+      "Rotation": 169.729568,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "eb9c6017-661e-409c-9bb6-ec997683109d",
+      "Infiltration": "E6_1",
+      "Position": {
+        "x": -173.311,
+        "y": 2.455,
+        "z": 467.431
+      },
+      "Rotation": 181.253433,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "ecafbe6f-9432-4728-b829-4a2f6530364d",
+      "Infiltration": "E2_3",
+      "Position": {
+        "x": 272.043,
+        "y": 4.773,
+        "z": 516.173
+      },
+      "Rotation": 236.6915,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "edd5229f-7229-4ef0-9093-daaac227f875",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 272.319,
+        "y": -4.493,
+        "z": 87.688
+      },
+      "Rotation": 93.71277,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "edd7c49a-54a8-4c4e-a913-1e2bffadc20c",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 49.31,
+        "y": 0.553,
+        "z": 43.803
+      },
+      "Rotation": 109.729546,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneCinema",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 4,
+      "DelayToCanSpawnSec": 40,
+      "Id": "ee82e417-dac2-4eb0-b20b-10e35f949a10",
+      "Infiltration": "",
+      "Position": {
+        "x": -135.905,
+        "y": 2.545,
+        "z": 395.469
+      },
+      "Rotation": 180,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 7,
+      "DelayToCanSpawnSec": 40,
+      "Id": "ef4fa3b5-82ba-408f-bf19-c33ee5c94795",
+      "Infiltration": "",
+      "Position": {
+        "x": -159.77,
+        "y": 0.74,
+        "z": -21.0299988
+      },
+      "Rotation": 8.731616,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "ef5737c8-b0f7-4db9-a986-4206aea8fbb1",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -42.919,
+        "y": 6.677,
+        "z": -117.171
+      },
+      "Rotation": 272.519379,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Opposite"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "f0113a3b-12cd-4801-ad39-c5ebc9578d38",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": -2.44697571,
+        "y": 1.65800035,
+        "z": 151.275
+      },
+      "Rotation": 3.67021,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW01",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "f0816d5a-a550-4efd-ab49-495f3c05969c",
+      "Infiltration": "",
+      "Position": {
+        "x": 75.18001,
+        "y": -0.629997253,
+        "z": 92.28
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "f2e231e6-a45f-4f2a-a220-eb2fb3acd888",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 91.666,
+        "y": 2.579,
+        "z": 450.023
+      },
+      "Rotation": 169.729568,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "f2f4ba88-575b-41f9-b1e4-7f611a152dd9",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": -10.48,
+        "y": 2.763,
+        "z": -137.96
+      },
+      "Rotation": 92.51915,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSnipeSW01",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 90
+        }
+      },
+      "CorePointId": 13,
+      "DelayToCanSpawnSec": 40,
+      "Id": "f304ac9e-75de-4507-ae4d-a60292f32173",
+      "Infiltration": "",
+      "Position": {
+        "x": 89.28,
+        "y": 35.02,
+        "z": 101.34
+      },
+      "Rotation": 270,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneColumn",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 14,
+      "DelayToCanSpawnSec": 40,
+      "Id": "f308263f-2bf8-4bf9-ba7c-b22532d80d0b",
+      "Infiltration": "",
+      "Position": {
+        "x": 38.27,
+        "y": 2.159,
+        "z": 196.95
+      },
+      "Rotation": 301.882233,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "f3b6a67b-2630-487a-aec0-56062d52e87e",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 186.308,
+        "y": 1.65,
+        "z": 186.469
+      },
+      "Rotation": 24.4516544,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 2,
+      "DelayToCanSpawnSec": 40,
+      "Id": "f53d582a-9a4d-444b-b5ea-76437687bcbd",
+      "Infiltration": "",
+      "Position": {
+        "x": 142.932,
+        "y": 6.69,
+        "z": 361.238
+      },
+      "Rotation": 0,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "f61741a7-b439-4440-a914-045560725ade",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -115.14,
+        "y": 0.873,
+        "z": 64.97
+      },
+      "Rotation": 101.2029,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "f61dc8f4-8ab8-4a1b-9771-8c4d26568769",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 9.347992,
+        "y": 1.77900016,
+        "z": 153.493988
+      },
+      "Rotation": 57.23363,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "f6b9cd44-6c11-4c17-ac58-897b2af338ac",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 155.154,
+        "y": 3.624,
+        "z": 430.339
+      },
+      "Rotation": 169.729568,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "f6cc8fe9-efc2-4b01-bd68-87565e068436",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": -29.893,
+        "y": 2.615,
+        "z": 465.548
+      },
+      "Rotation": 181.253433,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "f76c8faa-fb5a-480a-8792-0ef7c6ff2b08",
+      "Infiltration": "",
+      "Position": {
+        "x": 224.400009,
+        "y": 0.458999634,
+        "z": 219.96
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "f84db9e0-7354-4698-8148-7658bc92e22d",
+      "Infiltration": "",
+      "Position": {
+        "x": 192.330017,
+        "y": 1.06999969,
+        "z": 221.81
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneFactory",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 5,
+      "DelayToCanSpawnSec": 40,
+      "Id": "f92942c9-478c-420f-b718-7b7911515471",
+      "Infiltration": "",
+      "Position": {
+        "x": -100.35,
+        "y": 2.32,
+        "z": 268.45
+      },
+      "Rotation": 90,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW00",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 17,
+      "DelayToCanSpawnSec": 40,
+      "Id": "fa013277-b1d7-4859-8013-886d43d3c033",
+      "Infiltration": "",
+      "Position": {
+        "x": 172.87001,
+        "y": 0.544002533,
+        "z": 154.790009
+      },
+      "Rotation": 73.40837,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSnipeStilo",
+      "Categories": [
+        "Bot"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 90
+        }
+      },
+      "CorePointId": 18,
+      "DelayToCanSpawnSec": 40,
+      "Id": "fa2765ea-3bb2-403f-8e03-7241fd902fae",
+      "Infiltration": "",
+      "Position": {
+        "x": -119.24,
+        "y": 14.9,
+        "z": -12.25
+      },
+      "Rotation": 11.7017088,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 65
+        }
+      },
+      "CorePointId": 3,
+      "DelayToCanSpawnSec": 40,
+      "Id": "fac06407-cc0c-4f05-840d-72274d663839",
+      "Infiltration": "",
+      "Position": {
+        "x": 71.815,
+        "y": 2.701,
+        "z": 266.432
+      },
+      "Rotation": 93.85756,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneColumn",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 60
+        }
+      },
+      "CorePointId": 14,
+      "DelayToCanSpawnSec": 40,
+      "Id": "fb14cf70-d929-4f59-ba32-676e81b94c26",
+      "Infiltration": "",
+      "Position": {
+        "x": -16.204,
+        "y": 2.633,
+        "z": 253.572
+      },
+      "Rotation": 111.727104,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "fb27922a-bde1-4d4e-8d54-2bebcc0985d4",
+      "Infiltration": "E1_2",
+      "Position": {
+        "x": 95.66,
+        "y": 2.65,
+        "z": 448.81
+      },
+      "Rotation": 169.729568,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "fc8c0d11-fecf-4e65-9b95-ec8afe78073d",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 244.69,
+        "y": -3.21,
+        "z": -35.49
+      },
+      "Rotation": 259.729858,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 30
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "fd538d06-6c39-4b38-8386-c45d0ed446b1",
+      "Infiltration": "E4_5",
+      "Position": {
+        "x": -46.121,
+        "y": 6.062,
+        "z": -114.006
+      },
+      "Rotation": 272.519379,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Coop",
+        "Group"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "fd6734ed-6ba8-423b-8a7b-2943f31c6527",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 3.097992,
+        "y": 1.77900016,
+        "z": 155.593964
+      },
+      "Rotation": 57.23363,
+      "Sides": [
+        "Pmc"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneSW01",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 55
+        }
+      },
+      "CorePointId": 1,
+      "DelayToCanSpawnSec": 40,
+      "Id": "fda314da-ebe3-4116-9140-57825b8a9c7f",
+      "Infiltration": "",
+      "Position": {
+        "x": 117.27002,
+        "y": 0.580001831,
+        "z": 188.66
+      },
+      "Rotation": 264.516571,
+      "Sides": [
+        "Savage"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 35
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "fe07dac4-1e9e-4ec8-9a4a-aef4c2fbe6aa",
+      "Infiltration": "E5_6",
+      "Position": {
+        "x": -242.591,
+        "y": 3.685,
+        "z": 242.089
+      },
+      "Rotation": 205,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "fe111b2d-c512-47e8-b233-8b34d46d4595",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 260.742,
+        "y": -5.94,
+        "z": 48.666
+      },
+      "Rotation": 319.729767,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "",
+      "Categories": [
+        "Player"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 50
+        }
+      },
+      "CorePointId": 0,
+      "DelayToCanSpawnSec": 4,
+      "Id": "fe3633fa-5a3d-46f1-9c56-8f30c2b61cc1",
+      "Infiltration": "E3_4",
+      "Position": {
+        "x": 170.078,
+        "y": -1.451,
+        "z": -132.837
+      },
+      "Rotation": 268.9683,
+      "Sides": [
+        "All"
+      ]
+    },
+    {
+      "BotZoneName": "ZoneStilo",
+      "Categories": [
+        "All"
+      ],
+      "ColliderParams": {
+        "_parent": "SpawnSphereParams",
+        "_props": {
+          "Center": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "Radius": 45
+        }
+      },
+      "CorePointId": 15,
+      "DelayToCanSpawnSec": 40,
+      "Id": "fedb471b-f48f-40c1-bcde-b55968a5eb67",
+      "Infiltration": "",
+      "Position": {
+        "x": -2.675,
+        "y": -3.71,
+        "z": -4.22299957
+      },
+      "Rotation": 162.1,
+      "Sides": [
+        "Savage"
+      ]
+    }
+  ],
+  "UnixDateTime": 1621511450,
+  "_Id": "5714dc692459777137212e12",
+  "doors": [],
+  "exit_access_time": 40,
+  "exit_count": 1,
+  "exit_time": 2,
+  "exits": [
+    {
+      "Chance": 100,
+      "Count": 0,
+      "EntryPoints": "E1_2,E6_1,E2_3,E3_4,E4_5,E5_6,E6_1",
+      "EventAvailable": true,
+      "ExfiltrationTime": 8,
+      "ExfiltrationType": "Individual",
+      "Id": "",
+      "MaxTime": 0,
+      "MinTime": 0,
+      "Name": "E1",
+      "PassageRequirement": "None",
+      "PlayersCount": 0,
+      "RequiredSlot": "FirstPrimaryWeapon",
+      "RequirementTip": ""
+    },
+    {
+      "Chance": 100,
+      "Count": 0,
+      "EntryPoints": "E1_2,E6_1,E2_3,E3_4,E4_5,E5_6,E6_1",
+      "EventAvailable": true,
+      "ExfiltrationTime": 8,
+      "ExfiltrationType": "Individual",
+      "Id": "",
+      "MaxTime": 0,
+      "MinTime": 0,
+      "Name": "E2",
+      "PassageRequirement": "None",
+      "PlayersCount": 0,
+      "RequiredSlot": "FirstPrimaryWeapon",
+      "RequirementTip": ""
+    },
+    {
+      "Chance": 100,
+      "Count": 0,
+      "EntryPoints": "E1_2,E6_1,E2_3,E3_4,E4_5,E5_6,E6_1",
+      "EventAvailable": true,
+      "ExfiltrationTime": 8,
+      "ExfiltrationType": "Individual",
+      "Id": "",
+      "MaxTime": 0,
+      "MinTime": 0,
+      "Name": "E3",
+      "PassageRequirement": "None",
+      "PlayersCount": 0,
+      "RequiredSlot": "FirstPrimaryWeapon",
+      "RequirementTip": ""
+    },
+    {
+      "Chance": 100,
+      "Count": 0,
+      "EntryPoints": "E1_2,E6_1,E2_3,E3_4,E4_5,E5_6,E6_1",
+      "EventAvailable": true,
+      "ExfiltrationTime": 8,
+      "ExfiltrationType": "Individual",
+      "Id": "",
+      "MaxTime": 0,
+      "MinTime": 0,
+      "Name": "E4",
+      "PassageRequirement": "None",
+      "PlayersCount": 0,
+      "RequiredSlot": "FirstPrimaryWeapon",
+      "RequirementTip": ""
+    },
+    {
+      "Chance": 100,
+      "Count": 0,
+      "EntryPoints": "E1_2,E6_1,E2_3,E3_4,E4_5,E5_6,E6_1",
+      "EventAvailable": true,
+      "ExfiltrationTime": 8,
+      "ExfiltrationType": "Individual",
+      "Id": "",
+      "MaxTime": 0,
+      "MinTime": 0,
+      "Name": "E5",
+      "PassageRequirement": "None",
+      "PlayersCount": 0,
+      "RequiredSlot": "FirstPrimaryWeapon",
+      "RequirementTip": ""
+    },
+    {
+      "Chance": 0,
+      "Count": 0,
+      "EntryPoints": "E6_1,E5_6",
+      "EventAvailable": false,
+      "ExfiltrationTime": 8,
+      "ExfiltrationType": "Individual",
+      "Id": "",
+      "MaxTime": 0,
+      "MinTime": 0,
+      "Name": "E6",
+      "PassageRequirement": "None",
+      "PlayersCount": 0,
+      "RequiredSlot": "FirstPrimaryWeapon",
+      "RequirementTip": ""
+    },
+    {
+      "Chance": 50,
+      "Count": 5000,
+      "EntryPoints": "E1_2,E6_1,E2_3,E3_4,E4_5,E5_6,E6_1",
+      "EventAvailable": false,
+      "ExfiltrationTime": 60,
+      "ExfiltrationType": "SharedTimer",
+      "Id": "5449016a4bdc2d6f028b456f",
+      "MaxTime": 0,
+      "MinTime": 0,
+      "Name": "E7_car",
+      "PassageRequirement": "TransferItem",
+      "PlayersCount": 4,
+      "RequiredSlot": "FirstPrimaryWeapon",
+      "RequirementTip": "EXFIL_Item"
+    },
+    {
+      "Chance": 40,
+      "Count": 0,
+      "EntryPoints": "E1_2,E6_1,E2_3,E3_4,E4_5,E5_6,E6_1",
+      "EventAvailable": false,
+      "ExfiltrationTime": 8,
+      "ExfiltrationType": "Individual",
+      "Id": "",
+      "MaxTime": 0,
+      "MinTime": 0,
+      "Name": "E8_yard",
+      "PassageRequirement": "None",
+      "PlayersCount": 0,
+      "RequiredSlot": "FirstPrimaryWeapon",
+      "RequirementTip": ""
+    },
+    {
+      "Chance": 100,
+      "Count": 0,
+      "EntryPoints": "E1_2,E6_1,E2_3,E3_4,E4_5,E5_6,E6_1",
+      "EventAvailable": false,
+      "ExfiltrationTime": 6,
+      "ExfiltrationType": "Individual",
+      "Id": "",
+      "MaxTime": 0,
+      "MinTime": 0,
+      "Name": "E9_sniper",
+      "PassageRequirement": "None",
+      "PlayersCount": 0,
+      "RequiredSlot": "FirstPrimaryWeapon",
+      "RequirementTip": ""
+    },
+    {
+      "Chance": 100,
+      "Count": 0,
+      "EntryPoints": "E1_2,E6_1,E2_3,E3_4,E4_5,E5_6,E6_1",
+      "EventAvailable": false,
+      "ExfiltrationTime": 8,
+      "ExfiltrationType": "SharedTimer",
+      "Id": "",
+      "MaxTime": 0,
+      "MinTime": 0,
+      "Name": "Exit_E10_coop",
+      "PassageRequirement": "ScavCooperation",
+      "PlayersCount": 0,
+      "RequiredSlot": "FirstPrimaryWeapon",
+      "RequirementTip": "EXFIL_Cooperate"
+    },
+    {
+      "Chance": 100,
+      "Count": 0,
+      "EntryPoints": "E1_2,E6_1,E2_3,E3_4,E4_5,E5_6,E6_1",
+      "EventAvailable": true,
+      "ExfiltrationTime": 8,
+      "ExfiltrationType": "Individual",
+      "Id": "",
+      "MaxTime": 0,
+      "MinTime": 0,
+      "Name": "E7",
+      "PassageRequirement": "None",
+      "PlayersCount": 0,
+      "RequiredSlot": "FirstPrimaryWeapon",
+      "RequirementTip": ""
+    },
+    {
+      "Chance": 100,
+      "Count": 0,
+      "EntryPoints": "E1_2,E6_1,E2_3,E3_4,E4_5,E5_6,E6_1",
+      "EventAvailable": true,
+      "ExfiltrationTime": 8,
+      "ExfiltrationType": "Individual",
+      "Id": "",
+      "MaxTime": 0,
+      "MinTime": 0,
+      "Name": "E8",
+      "PassageRequirement": "None",
+      "PlayersCount": 0,
+      "RequiredSlot": "FirstPrimaryWeapon",
+      "RequirementTip": ""
+    }
+  ],
+  "filter_ex": [],
+  "limits": [
+    {
+      "items": [
+        "64d4b23dc1b37504b41ac2b6"
+      ],
+      "max": 1,
+      "min": 1
+    }
+  ],
+  "matching_min_seconds": 60,
+  "sav_summon_seconds": 60,
+  "tmp_location_field_remove_me": 0,
+  "users_gather_seconds": 0,
+  "users_spawn_seconds_n": 120,
+  "users_spawn_seconds_n2": 200,
+  "users_summon_seconds": 0,
+  "waves": [
+    {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneSW01",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 0,
+      "slots_max": 3,
+      "slots_min": 0,
+      "time_max": 60,
+      "time_min": 10
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneConstruction",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 1,
+      "slots_max": 4,
+      "slots_min": 0,
+      "time_max": 60,
+      "time_min": 10
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneCarShowroom",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 2,
+      "slots_max": 5,
+      "slots_min": 0,
+      "time_max": 60,
+      "time_min": 10
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneCinema",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 3,
+      "slots_max": 3,
+      "slots_min": 0,
+      "time_max": 60,
+      "time_min": 10
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneFactory",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 4,
+      "slots_max": 3,
+      "slots_min": 0,
+      "time_max": 60,
+      "time_min": 10
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneHotel_1",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 5,
+      "slots_max": 3,
+      "slots_min": 0,
+      "time_max": 60,
+      "time_min": 10
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneHotel_2",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 6,
+      "slots_max": 3,
+      "slots_min": 0,
+      "time_max": 60,
+      "time_min": 10
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneConcordia_1",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 7,
+      "slots_max": 3,
+      "slots_min": 0,
+      "time_max": 60,
+      "time_min": 10
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneColumn",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 8,
+      "slots_max": 3,
+      "slots_min": 0,
+      "time_max": 60,
+      "time_min": 10
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneConcordiaParking",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 9,
+      "slots_max": 2,
+      "slots_min": 0,
+      "time_max": 60,
+      "time_min": 10
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneSnipeCinema",
+      "WildSpawnType": "marksman",
+      "isPlayers": false,
+      "number": 10,
+      "slots_max": 2,
+      "slots_min": 0,
+      "time_max": 60,
+      "time_min": 10
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneSnipeCarShowroom",
+      "WildSpawnType": "marksman",
+      "isPlayers": false,
+      "number": 11,
+      "slots_max": 2,
+      "slots_min": 0,
+      "time_max": 60,
+      "time_min": 10
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneSnipeBuilding",
+      "WildSpawnType": "marksman",
+      "isPlayers": false,
+      "number": 12,
+      "slots_max": 2,
+      "slots_min": 0,
+      "time_max": 60,
+      "time_min": 10
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneSnipeSW01",
+      "WildSpawnType": "marksman",
+      "isPlayers": false,
+      "number": 13,
+      "slots_max": 2,
+      "slots_min": 0,
+      "time_max": 60,
+      "time_min": 10
+  },
+  {
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneSW01",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 14,
+    "slots_max": 3,
+    "slots_min": 0,
+    "time_max": 600,
+    "time_min": 120
+},
+{
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneConstruction",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 15,
+    "slots_max": 4,
+    "slots_min": 0,
+    "time_max": 600,
+    "time_min": 120
+},
+{
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneCarShowroom",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 16,
+    "slots_max": 5,
+    "slots_min": 0,
+    "time_max": 600,
+    "time_min": 120
+},
+{
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneCinema",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 17,
+    "slots_max": 3,
+    "slots_min": 0,
+    "time_max": 600,
+    "time_min": 120
+},
+{
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneFactory",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 18,
+    "slots_max": 3,
+    "slots_min": 0,
+    "time_max": 600,
+    "time_min": 120
+},
+{
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneHotel_1",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 19,
+    "slots_max": 3,
+    "slots_min": 0,
+    "time_max": 600,
+    "time_min": 120
+},
+{
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneHotel_2",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 20,
+    "slots_max": 3,
+    "slots_min": 0,
+    "time_max": 600,
+    "time_min": 120
+},
+{
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneConcordia_1",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 21,
+    "slots_max": 3,
+    "slots_min": 0,
+    "time_max": 600,
+    "time_min": 120
+},
+{
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneColumn",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 22,
+    "slots_max": 3,
+    "slots_min": 0,
+    "time_max": 600,
+    "time_min": 120
+},
+{
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneConcordiaParking",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 23,
+    "slots_max": 2,
+    "slots_min": 0,
+    "time_max": 600,
+    "time_min": 120
+},
+{
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneSnipeCinema",
+    "WildSpawnType": "marksman",
+    "isPlayers": false,
+    "number": 24,
+    "slots_max": 2,
+    "slots_min": 0,
+    "time_max": 600,
+    "time_min": 120
+},
+{
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneSnipeCarShowroom",
+    "WildSpawnType": "marksman",
+    "isPlayers": false,
+    "number": 25,
+    "slots_max": 2,
+    "slots_min": 0,
+    "time_max": 600,
+    "time_min": 120
+},
+{
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneSnipeBuilding",
+    "WildSpawnType": "marksman",
+    "isPlayers": false,
+    "number": 26,
+    "slots_max": 2,
+    "slots_min": 0,
+    "time_max": 600,
+    "time_min": 120
+},
+{
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneSnipeSW01",
+    "WildSpawnType": "marksman",
+    "isPlayers": false,
+    "number": 27,
+    "slots_max": 2,
+    "slots_min": 0,
+    "time_max": 600,
+    "time_min": 120
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneSW01",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 28,
+      "slots_max": 3,
+      "slots_min": 0,
+      "time_max": 1200,
+      "time_min": 600
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneConstruction",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 29,
+      "slots_max": 4,
+      "slots_min": 0,
+      "time_max": 1200,
+      "time_min": 600
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneCarShowroom",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 30,
+      "slots_max": 5,
+      "slots_min": 0,
+      "time_max": 1200,
+      "time_min": 600
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneCinema",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 31,
+      "slots_max": 3,
+      "slots_min": 0,
+      "time_max": 1200,
+      "time_min": 600
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneFactory",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 32,
+      "slots_max": 3,
+      "slots_min": 0,
+      "time_max": 1200,
+      "time_min": 600
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneHotel_1",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 33,
+      "slots_max": 3,
+      "slots_min": 0,
+      "time_max": 1200,
+      "time_min": 600
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneHotel_2",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 34,
+      "slots_max": 3,
+      "slots_min": 0,
+      "time_max": 1200,
+      "time_min": 600
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneConcordia_1",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 35,
+      "slots_max": 3,
+      "slots_min": 0,
+      "time_max": 1200,
+      "time_min": 600
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneColumn",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 36,
+      "slots_max": 3,
+      "slots_min": 0,
+      "time_max": 1200,
+      "time_min": 600
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneConcordiaParking",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 37,
+      "slots_max": 2,
+      "slots_min": 0,
+      "time_max": 1200,
+      "time_min": 600
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneSnipeCinema",
+      "WildSpawnType": "marksman",
+      "isPlayers": false,
+      "number": 38,
+      "slots_max": 2,
+      "slots_min": 0,
+      "time_max": 1200,
+      "time_min": 600
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneSnipeCarShowroom",
+      "WildSpawnType": "marksman",
+      "isPlayers": false,
+      "number": 39,
+      "slots_max": 2,
+      "slots_min": 0,
+      "time_max": 1200,
+      "time_min": 600
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneSnipeBuilding",
+      "WildSpawnType": "marksman",
+      "isPlayers": false,
+      "number": 40,
+      "slots_max": 2,
+      "slots_min": 0,
+      "time_max": 1200,
+      "time_min": 600
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "ZoneSnipeSW01",
+      "WildSpawnType": "marksman",
+      "isPlayers": false,
+      "number": 41,
+      "slots_max": 2,
+      "slots_min": 0,
+      "time_max": 1200,
+      "time_min": 600
+  },
+  {
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneSW01",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 42,
+    "slots_max": 3,
+    "slots_min": 0,
+    "time_max": 2400,
+    "time_min": 1200
+  },
+  {
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneConstruction",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 43,
+    "slots_max": 4,
+    "slots_min": 0,
+    "time_max": 2400,
+    "time_min": 1200
+  },
+  {
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneCarShowroom",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 44,
+    "slots_max": 5,
+    "slots_min": 0,
+    "time_max": 2400,
+    "time_min": 1200
+  },
+  {
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneCinema",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 45,
+    "slots_max": 3,
+    "slots_min": 0,
+    "time_max": 2400,
+    "time_min": 1200
+  },
+  {
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneFactory",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 46,
+    "slots_max": 3,
+    "slots_min": 0,
+    "time_max": 2400,
+    "time_min": 1200
+  },
+  {
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneHotel_1",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 47,
+    "slots_max": 3,
+    "slots_min": 0,
+    "time_max": 2400,
+    "time_min": 1200
+  },
+  {
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneHotel_2",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 48,
+    "slots_max": 3,
+    "slots_min": 0,
+    "time_max": 2400,
+    "time_min": 1200
+  },
+  {
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneConcordia_1",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 49,
+    "slots_max": 3,
+    "slots_min": 0,
+    "time_max": 2400,
+    "time_min": 1200
+  },
+  { 
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneColumn",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 50,
+    "slots_max": 3,
+    "slots_min": 0,
+    "time_max": 2400,
+    "time_min": 1200
+  },
+  {
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneConcordiaParking",
+    "WildSpawnType": "assault",
+    "isPlayers": true,
+    "number": 51,
+    "slots_max": 2,
+    "slots_min": 0,
+    "time_max": 2400,
+    "time_min": 1200
+  },
+  {
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneSnipeCinema",
+    "WildSpawnType": "marksman",
+    "isPlayers": false,
+    "number": 52,
+    "slots_max": 2,
+    "slots_min": 0,
+    "time_max": 2400,
+    "time_min": 1200
+  },
+  {
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneSnipeCarShowroom",
+    "WildSpawnType": "marksman",
+    "isPlayers": false,
+    "number": 53,
+    "slots_max": 2,
+    "slots_min": 0,
+    "time_max": 2400,
+    "time_min": 1200
+  },
+  {
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneSnipeBuilding",
+    "WildSpawnType": "marksman",
+    "isPlayers": false,
+    "number": 54,
+    "slots_max": 2,
+    "slots_min": 0,
+    "time_max": 2400,
+    "time_min": 1200
+  },
+  {
+    "BotPreset": "normal",
+    "BotSide": "Savage",
+    "SpawnPoints": "ZoneSnipeSW01",
+    "WildSpawnType": "marksman",
+    "isPlayers": false,
+    "number": 55,
+    "slots_max": 2,
+    "slots_min": 0,
+    "time_max": 2400,
+    "time_min": 1200
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 56,
+      "slots_max": 4,
+      "slots_min": 0,
+      "time_max": 2100,
+      "time_min": 600
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 57,
+      "slots_max": 4,
+      "slots_min": 0,
+      "time_max": 2100,
+      "time_min": 600
+  },
+  {
+      "BotPreset": "normal",
+      "BotSide": "Savage",
+      "SpawnPoints": "",
+      "WildSpawnType": "assault",
+      "isPlayers": true,
+      "number": 58,
+      "slots_max": 4,
+      "slots_min": 0,
+      "time_max": 2100,
+      "time_min": 600
+  }
+  ]
+}


### PR DESCRIPTION
Updated current 3.7.6 changes on factory4_day and tarkovstreets maps to rebalance for a Standard_vanila_bosses setup.

Changes include:  
1. Remove killa, raider, and knight/birdeye/big pipe spawns from factory.  
2. Set scav waves to normal difficulty and set isPlayers boolean to false for sniper scavs.